### PR TITLE
fix: CI validates wrong .md file — should target SKILL.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,10 @@ jobs:
         run: |
           ERRORS=0
           for dir in skills/*/; do
-            SKILL_FILE=$(find "$dir" -maxdepth 1 -name '*.md' | head -1)
-            if [ -z "$SKILL_FILE" ]; then
-              echo "::warning::No .md file in $dir"
+            SKILL_FILE="${dir}SKILL.md"
+            if [ ! -f "$SKILL_FILE" ]; then
+              echo "::error::Missing SKILL.md in $dir"
+              ERRORS=$((ERRORS + 1))
               continue
             fi
 


### PR DESCRIPTION
## Summary

- CI 每次都失败，原因是 `find ... -name '*.md' | head -1` 在 Linux 上拿到的不一定是 `SKILL.md`
- 辅助文件（如 `CREATION-LOG.md`、`code-quality-reviewer-prompt.md`）没有 frontmatter，导致 4 个误报
- 修复：直接检查 `SKILL.md`，如果缺失则报错

## Root Cause

```bash
# Before: find returns files in inode order on Linux, not alphabetical
SKILL_FILE=$(find "$dir" -maxdepth 1 -name '*.md' | head -1)
# Could return CREATION-LOG.md instead of SKILL.md

# After: always target the canonical skill definition file
SKILL_FILE="${dir}SKILL.md"
```

## Verification

Ran the updated validation logic locally against all 20 skill directories — 20/20 pass, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)