### PR TITLE
fix: add missing name field to deprecated command frontmatter

### DIFF
--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -1,4 +1,5 @@
 ---
+name: brainstorm
 description: "已弃用 - 请改用 superpowers:brainstorming 技能"
 ---
 

--- a/commands/execute-plan.md
+++ b/commands/execute-plan.md
@@ -1,4 +1,5 @@
 ---
+name: execute-plan
 description: "已弃用 - 请改用 superpowers:executing-plans 技能"
 ---
 

--- a/commands/write-plan.md
+++ b/commands/write-plan.md
@@ -1,4 +1,5 @@
 ---
+name: write-plan
 description: "已弃用 - 请改用 superpowers:writing-plans 技能"
 ---
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

All three deprecated command stubs — `commands/brainstorm.md`, `commands/write-plan.md`, and `commands/execute-plan.md` — are missing the `name` field in their YAML frontmatter.

According to the Claude Code plugin conventions, the `name` field is used for name-based plugin discovery and is expected to be present in command frontmatter. Its absence means plugin tooling that indexes commands by name (e.g. for autocomplete, validation, or slash command routing) may silently skip or fail to find these commands.

## Fix

Added a one-line `name` field to each command's frontmatter, matching the filename:

- `commands/brainstorm.md` → `name: brainstorm`
- `commands/write-plan.md` → `name: write-plan`
- `commands/execute-plan.md` → `name: execute-plan`

These are purely mechanical, one-line additions with no behavioral change to the commands themselves.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->