### PR TITLE
fix: tighten Node engine constraint from >=14 to >=18

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "superpowers-zh",
   "version": "1.1.8",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=18.0.0"
   },
   "description": "AI 编程超能力中文增强版 — superpowers（99k+ ⭐）完整汉化 + 6 个中国原创 skills，支持 Claude Code / Copilot CLI / Hermes Agent / Cursor / Claw Code / Windsurf / Kiro / Gemini CLI 等 17 款工具",
   "type": "module",


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug / Security Fix (Low severity)

`package.json` currently declares `"node": ">=14.0.0"`, which permits installation on Node 14 and Node 16 — both reached end-of-life in 2023 and have documented CVEs in their OpenSSL and other bundled components.

## Fix

Changed the engines constraint to `"node": ">=18.0.0"`. Node 18 is the oldest actively maintained LTS line. This change:

- Prevents accidental use on EOL runtimes with known vulnerabilities
- Does not affect any user running a currently supported Node version (18, 20, 22, or later)
- Is a one-line edit with no functional code changes

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->