### PR TITLE
fix: npx 装 Claude Code 目标时补上 CLAUDE.md bootstrap

### DIFF
--- a/bin/superpowers-zh.js
+++ b/bin/superpowers-zh.js
@@ -299,6 +299,49 @@ ${skillList}
   }
 }
 
+function generateClaudeCodeBootstrap(projectDir) {
+  const skillEntries = scanSkillEntries(SKILLS_SRC);
+  const skillList = skillEntries.map(s => `- **${s.name}**: ${s.desc}`).join('\n');
+
+  const content = `# Superpowers-ZH 中文增强版
+
+本项目已安装 superpowers-zh 技能框架（${skillEntries.length} 个 skills）。
+
+## 核心规则
+
+1. **收到任务时，先检查是否有匹配的 skill** — 哪怕只有 1% 的可能性也要检查
+2. **设计先于编码** — 收到功能需求时，先用 brainstorming skill 做需求分析
+3. **测试先于实现** — 写代码前先写测试（TDD）
+4. **验证先于完成** — 声称完成前必须运行验证命令
+
+## 可用 Skills
+
+Skills 位于 \`.claude/skills/\` 目录，每个 skill 有独立的 \`SKILL.md\` 文件。
+
+${skillList}
+
+## 如何使用
+
+当任务匹配某个 skill 时，使用 \`Skill\` 工具加载对应 skill 并严格遵循其流程。绝不要用 Read 工具读取 SKILL.md 文件。
+
+如果你认为哪怕只有 1% 的可能性某个 skill 适用于你正在做的事情，你必须调用该 skill 检查。
+`;
+
+  const mdPath = resolve(projectDir, 'CLAUDE.md');
+  if (existsSync(mdPath)) {
+    const existing = readFileSync(mdPath, 'utf8');
+    if (!existing.includes('superpowers-zh')) {
+      writeFileSync(mdPath, existing + '\n\n' + content, 'utf8');
+      console.log(`  ✅ Claude Code: 追加 skills 引用 -> ${mdPath}`);
+    } else {
+      console.log(`  ✅ Claude Code: CLAUDE.md 已包含 superpowers-zh 引用`);
+    }
+  } else {
+    writeFileSync(mdPath, content, 'utf8');
+    console.log(`  ✅ Claude Code: bootstrap -> ${mdPath}`);
+  }
+}
+
 // 工具名称别名映射（用户输入 -> TARGETS.name）
 const TOOL_ALIASES = {
   'claude':       'Claude Code',
@@ -390,10 +433,13 @@ function installForTarget(target) {
     generateHermesBootstrap(PROJECT_DIR);
   }
 
-  if (target.name === 'Claude Code' && existsSync(AGENTS_SRC)) {
-    const agentsDest = resolve(PROJECT_DIR, '.claude', 'agents');
-    mkdirSync(agentsDest, { recursive: true });
-    copyDirSync(AGENTS_SRC, agentsDest);
+  if (target.name === 'Claude Code') {
+    generateClaudeCodeBootstrap(PROJECT_DIR);
+    if (existsSync(AGENTS_SRC)) {
+      const agentsDest = resolve(PROJECT_DIR, '.claude', 'agents');
+      mkdirSync(agentsDest, { recursive: true });
+      copyDirSync(AGENTS_SRC, agentsDest);
+    }
   }
 }
 
@@ -444,6 +490,8 @@ function install(forceToolName) {
     mkdirSync(dest, { recursive: true });
     copyDirSync(SKILLS_SRC, dest);
     console.log(`  ✅ 默认安装: ${countDirs(dest)} 个 skills -> ${dest}`);
+
+    generateClaudeCodeBootstrap(PROJECT_DIR);
 
     if (existsSync(AGENTS_SRC)) {
       const agentsDest = resolve(PROJECT_DIR, '.claude', 'agents');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superpowers-zh",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "engines": {
     "node": ">=20.0.0"
   },


### PR DESCRIPTION
## 问题

`installForTarget` 对 Trae / Gemini / Aider / Antigravity / Hermes 都会自动生成 bootstrap 规则，写入对应工具的 rules 文件，告诉模型"任何任务前先查 skill"。**唯独 Claude Code（`.claude/` 分支）只复制 skills 和 agents，不写 CLAUDE.md 引导。**

后果：用户 `npx superpowers-zh` 装到 `.claude/` 后 skill 文件都在，但模型完全没被告知要主动用——提"加个导出功能"会直接写代码，不会走 `brainstorming → writing-plans` 的方法论流程。手动 `/brainstorming` 能触发，自动不触发。

## 改动

- 新增 `generateClaudeCodeBootstrap()`，对齐 Gemini/Aider 的"追加 or 新建"逻辑
- `installForTarget` 的 `.claude/` 分支调用它
- 默认回退分支（未检测到任何工具）也调用它
- **幂等**：已包含 `superpowers-zh` 引用则跳过
- 已有 `CLAUDE.md` 则追加，保留用户原内容

## 测试

本地验证四个场景，全部通过：
- [x] 空项目首次安装
- [x] 已有 CLAUDE.md（追加，不覆盖）
- [x] 二次安装（幂等）
- [x] `--tool claude` 强制指定

version bump: 1.1.8 → 1.1.9