### PR TITLE
fix(scripts): sync-plugin-version 支持嵌套字段路径，修 marketplace.json 卡在 1.1.8 的老漂移

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "superpowers-zh",
       "description": "AI 编程超能力中文增强版：20 个 skills（14 翻译 + 6 中国原创），支持 Claude Code / Hermes Agent / Cursor / Claw Code 等 17 款工具",
-      "version": "1.1.8",
+      "version": "1.2.1",
       "source": "./",
       "author": {
         "name": "jnMetaCode",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "superpowers-zh": "bin/superpowers-zh.js"
   },
   "scripts": {
-    "version": "node scripts/sync-plugin-version.js && git add .claude-plugin/plugin.json .cursor-plugin/plugin.json .codex-plugin/plugin.json"
+    "version": "node scripts/sync-plugin-version.js && git add .claude-plugin/plugin.json .claude-plugin/marketplace.json .cursor-plugin/plugin.json .codex-plugin/plugin.json"
   },
   "files": [
     "bin/",

--- a/scripts/sync-plugin-version.js
+++ b/scripts/sync-plugin-version.js
@@ -1,31 +1,57 @@
 #!/usr/bin/env node
-// 把 package.json 的 version 同步到 plugin manifest
-// 由 npm version 钩子触发，跑在 version commit 创建之前
+// 把 package.json 的 version 同步到所有 plugin manifest（含嵌套字段）。
+// 由 npm version 钩子触发，跑在 version commit 创建之前。
+//
+// 设计：用 regex 替换而不是 JSON.parse + stringify，目的是保留原文件格式
+// （缩进、行内/多行数组、空白等不被破坏）。每种 field 路径对应一个专用 regex。
 import { readFileSync, writeFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
-const targets = [
-  '.claude-plugin/plugin.json',
-  '.cursor-plugin/plugin.json',
-  '.codex-plugin/plugin.json',
+
+// targets 字段对齐上游 .version-bump.json 格式（path + field 路径）。
+// 顶层用 "version"，嵌套用 dot-path（如 "plugins.0.version"）。
+const TARGETS = [
+  { path: '.claude-plugin/plugin.json',      field: 'version' },
+  { path: '.cursor-plugin/plugin.json',      field: 'version' },
+  { path: '.codex-plugin/plugin.json',       field: 'version' },
+  { path: '.claude-plugin/marketplace.json', field: 'plugins.0.version' },
 ];
 
-let touched = 0;
-for (const rel of targets) {
-  const path = resolve(root, rel);
-  const text = readFileSync(path, 'utf8');
-  const json = JSON.parse(text);
-  if (json.version === pkg.version) continue;
-  // 只替换顶层 version 字段一行，保留原文件其他字段的格式（数组单行/多行、缩进等）
-  const updated = text.replace(/("version":\s*")[^"]+(")/, `$1${pkg.version}$2`);
-  if (updated === text) {
-    throw new Error(`未能在 ${rel} 中定位 version 字段`);
+function buildPattern(field) {
+  if (field === 'version') {
+    return /("version"\s*:\s*")[^"]+(")/;
   }
-  writeFileSync(path, updated, 'utf8');
-  console.log(`  ${rel}: ${json.version} -> ${pkg.version}`);
+  if (field === 'plugins.0.version') {
+    // 锚定到 "plugins": [ { ... 第一个对象内的 version 字段
+    return /("plugins"\s*:\s*\[\s*\{[\s\S]*?"version"\s*:\s*")[^"]+(")/;
+  }
+  throw new Error(`Unsupported field path: ${field}`);
+}
+
+function readField(json, field) {
+  if (field === 'version') return json.version;
+  if (field === 'plugins.0.version') return json.plugins?.[0]?.version;
+  throw new Error(`Unsupported field path: ${field}`);
+}
+
+let touched = 0;
+for (const { path: rel, field } of TARGETS) {
+  const fullPath = resolve(root, rel);
+  const text = readFileSync(fullPath, 'utf8');
+  const json = JSON.parse(text);
+  const current = readField(json, field);
+  if (current === pkg.version) continue;
+
+  const pattern = buildPattern(field);
+  const updated = text.replace(pattern, `$1${pkg.version}$2`);
+  if (updated === text) {
+    throw new Error(`未能在 ${rel} 中定位字段 ${field}`);
+  }
+  writeFileSync(fullPath, updated, 'utf8');
+  console.log(`  ${rel} (${field}): ${current} -> ${pkg.version}`);
   touched++;
 }
 if (touched === 0) console.log(`  plugin manifests already at ${pkg.version}`);


### PR DESCRIPTION
## Summary

接上 #22（v5.1.0 对齐 PR）。在那个 PR 的 sanity check 里发现的老漂移：

`.claude-plugin/marketplace.json` 的 `plugins[0].version` 一直停在 `1.1.8`，而其他 4 个 manifest（package.json + 3 个 plugin.json）已经在 `1.2.1`。原因是中文版用的简化版 `sync-plugin-version.js` 只 match 顶层 `"version":` 字段，处理不了嵌套路径。

## 实际影响

- Claude Code marketplace 用户看到的 `superpowers-zh` plugin 版本是 `1.1.8`，跟 npm 包真实版本不同步
- `git blame` 显示 marketplace.json 自 `v1.1.8` 起这个字段就没动过

## 改动

### `scripts/sync-plugin-version.js`
- `TARGETS` 改为对象数组 `{ path, field }`，对齐上游 `.version-bump.json` 格式
- 加入 `.claude-plugin/marketplace.json` 作为同步目标
- `field='version'`：保留原顶层 regex（保格式）
- `field='plugins.0.version'`：新增嵌套 regex `("plugins"\s*:\s*\[\s*\{[\s\S]*?"version"\s*:\s*")[^"]+(")`，锚定到 `plugins` 数组首项
- 都用 regex 替换而非 `JSON.stringify`，保持原文件格式（缩进、行内/多行数组等）

### `.claude-plugin/marketplace.json`
- `plugins[0].version`: `1.1.8` → `1.2.1`（追上其他 manifest）

### `package.json`
- `scripts.version` 钩子加入 `git add .claude-plugin/marketplace.json`

## Test plan

- [x] 当前状态跑 sync：marketplace.json 1.1.8 → 1.2.1，其他 4 个 manifest 不动（识别为 `already at`）
- [x] 升级场景：临时把 package.json bump 到 1.3.0，4 个 manifest 全部同步到 1.3.0
- [x] 幂等性：相同版本再跑输出 `plugin manifests already at 1.2.1`
- [x] 边界：marketplace.json diff 干净，只动 version 一行（owner/source/author/keywords 等其他字段完全没动）
- [x] `npm pack --dry-run`：90 文件 228KB（跟 #22 merge 后一致）
- [x] `node --check scripts/sync-plugin-version.js` 语法 OK
- [ ] CI 跑过

## 不在本 PR 内

- 不引入上游 `bump-version.sh` 替换简化版（改动太大，下次单独评估）
- 不支持任意 dot-path（仅 hardcode `version` 和 `plugins.0.version` 两种 case），避免过度工程；未来真有第 3 种再加
