### PR TITLE
docs(readme): 手动安装段加 low-fidelity 警示

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,15 @@ npx superpowers-zh
 
 > ⚠️ **不要在主目录（`~`）下跑**。v1.2.1 起会拒绝并提示，老版本会把 skills 和 `CLAUDE.md` 等 bootstrap 文件写到你的 home 目录，污染所有项目。如已误装见下文「卸载 / 误装清理」。
 
-### 方式二：手动安装
+### 方式二：手动安装（low-fidelity，仅作备选）
+
+> ⚠️ **手动 `cp -r skills` 是低保版安装，不等同于完整 plugin。**
+>
+> superpowers-zh 是一个完整 plugin，包含：`skills/`（20 个能力）+ `hooks/`（SessionStart 钩子，让 skill 在合适时机自动触发）+ `CLAUDE.md` / `GEMINI.md` 等 bootstrap 引导文件 + 4 套 plugin manifest（Claude Code / Cursor / Codex / Marketplace）。
+>
+> **下面的 `cp -r skills` 命令只复制 skills 目录**，不会自动配置 hooks、不会生成 bootstrap 引导。结果：skills 物理上存在，但 AI 不会在合适时机自动调用，需要你每次手动喊 "use brainstorming skill" 之类。
+>
+> **强烈推荐用方式一 `npx superpowers-zh`** —— 它会一键处理 skills 复制 + bootstrap 生成 + hooks 配置 + 工具特定适配。仅在 npx 不可用（极端无网络环境）时才退到手动。
 
 ```bash
 # 克隆仓库


### PR DESCRIPTION
## Summary

回应群友疑问：「superpowers-zh 是不是只有 skills、没 hooks/commands/agents 不完整？」

## 真正的根因

**不是 plugin 缺失**：v1.3.0 起 superpowers-zh 包含 `skills/` + `hooks/` + 4 套 plugin manifest（Claude Code / Cursor / Codex / Marketplace），是完整 plugin。`commands/` 和 `agents/` 是上游 v5.1.0 主动删的（deprecated stubs + agent 已 lift 进 skill），能力没缩水。

**是 README 误导**：「方式二：手动安装」段只展示 `cp -r skills`，没说还要复制 `hooks/` 和生成 bootstrap 引导文件。用户照着做，skills 物理存在但**不会自动触发**——这才是群友直觉里"丢失价值"的真正来源。

## 改动

`README.md` 第 149 行附近：

- 标题改为「方式二：手动安装（**low-fidelity，仅作备选**）」
- 顶部加 ⚠️ 提示框：
  - 说明 plugin 完整组成（skills + hooks + bootstrap + 4 套 manifest）
  - 说明 `cp -r skills` 实际丢什么（hooks 不配置、bootstrap 不生成、skills 不自动触发）
  - 强烈推荐回方式一 `npx superpowers-zh`
  - 把手动 cp 定位为「npx 不可用的极端无网络环境」备选

## Test plan

- [x] markdown 格式 OK（无 syntax error，✨提示框格式正常）
- [x] 不影响功能代码、CI 不需要重新 verify
- [ ] CI 跑过（pure docs change，应秒过）

## 不在本 PR 内

- 不展开手动 hooks 复制步骤（每个工具 hook 路径不同，写完会让 README 翻倍；用户走 npx 即可）
- 不改主 README 上方的"对比表"和"工具支持表"（那两个表已经隐含推荐 npx）
