### PR TITLE
docs(openclaw): 移除 stale slash command 引用，改自然语言触发

### DIFF
--- a/docs/README.openclaw.md
+++ b/docs/README.openclaw.md
@@ -62,11 +62,14 @@ OpenClaw 与 Claude Code 使用相同的工具名称，skills 无需额外适配
 
 ## 使用
 
-安装完成后重启 OpenClaw，所有 skills 会自动生效。你可以：
+安装完成后重启 OpenClaw，所有 skills 会自动生效。AI 会按任务上下文自动调用对应 skill：
 
-- 输入 `/brainstorming` 开始头脑风暴
-- 输入 `/commit` 使用中文提交规范
-- 在任何编码任务中，skills 会被自动调用
+- 新任务 / 新功能 → `brainstorming`（头脑风暴）
+- 写 commit message → `chinese-commit-conventions`（中文 commit 规范）
+- 调试问题 → `systematic-debugging`
+- 完成任务后 → `requesting-code-review`（请求代码审查）
+
+无需手动 slash command 触发 —— AI 通过 skill frontmatter 的 `description` 字段自主选择匹配的 skill。如果想强制触发某个 skill，直接在指令里点名："用 brainstorming 帮我想一下 X 怎么做"。
 
 ## 全局 Skills
 


### PR DESCRIPTION
## Summary

audit v1.3.0 release 时发现 `docs/README.openclaw.md` "使用"段还在写：

```
- 输入 `/brainstorming` 开始头脑风暴
- 输入 `/commit` 使用中文提交规范
```

两条都是过时/错误引用：

- `/brainstorming` 不是有效 slash command。`commands/` 目录在上游 v5.1.0 已删（我们 v1.3.0 跟随删除），而且我们 `commands/` 里**从来没有** `brainstorming` 这个名字（被删的是 `/brainstorm` / `/execute-plan` / `/write-plan`）。
- `/commit` 完全不存在 —— 我们没有 `commit` 这个 skill。最接近的是 `chinese-commit-conventions`，但 slash command 形式也不存在。
- 即便 `commands/` 还在的年代，OpenClaw 也不一定把 skill 自动暴露为 slash command（我没有 OpenClaw 环境验证，但官方文档没明确说支持）。

## 改动

`docs/README.openclaw.md` 第 63-70 行：

- 改写为 OpenClaw 实际生效的触发方式：AI 通过 skill frontmatter 的 `description` 字段自主选择 skill
- 给出 4 个高频场景示例（brainstorming / chinese-commit-conventions / systematic-debugging / requesting-code-review）
- 说明强制触发的方式（在指令里点名 skill）

## Test plan

- [x] markdown 语法 OK
- [x] 4 个 skill 名（brainstorming / chinese-commit-conventions / systematic-debugging / requesting-code-review）在仓库 `skills/` 目录下都存在
- [ ] CI 跑过

## 关联

audit 见 #19 评论（v1.3.0 release 后的全链路检查）。
