### PR TITLE
chore: release v1.4.0 — 上游漂移 P0 全量修复 + 防回归基建

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "superpowers-zh",
       "description": "AI 编程超能力中文增强版：20 个 skills（14 翻译 + 6 中国原创），支持 Claude Code / Hermes Agent / Cursor / Claw Code 等 17 款工具",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "source": "./",
       "author": {
         "name": "jnMetaCode",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superpowers-zh",
   "description": "AI 编程超能力中文增强版：20 个 skills（14 翻译 + 6 中国原创），支持 Claude Code / Hermes Agent / Cursor / Claw Code 等 17 款工具",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "jnMetaCode",
     "url": "https://github.com/jnMetaCode"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superpowers-zh",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "AI 编程超能力中文增强版：头脑风暴、subagent 驱动开发、规划、TDD、调试、代码审查、收尾工作流，附 4 个中文 skills 沉淀。",
   "author": {
     "name": "jnMetaCode",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "superpowers-zh",
   "displayName": "Superpowers 中文版",
   "description": "AI 编程超能力中文增强版：20 个 skills（14 翻译 + 6 中国原创），支持 Cursor / Claude Code / Hermes Agent / Claw Code 等 17 款工具",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "jnMetaCode",
     "url": "https://github.com/jnMetaCode"

--- a/RELEASE-NOTES.zh.md
+++ b/RELEASE-NOTES.zh.md
@@ -6,6 +6,84 @@
 
 ---
 
+## v1.4.0 (2026-05-12)
+
+本版本核心目标：**修复全量质量审计发现的所有上游漂移 P0 缺陷**。改动全部是"主站有的同步过来"性质，不引入主站没有的新功能。
+
+### 🔴 上游同步：v5.0.6 brainstorm server 拆分（PR #30）
+
+上游 v5.0.6（commit 9e3ed21）把 brainstorm server 的内容目录拆成 `CONTENT_DIR` + `STATE_DIR` peer 结构，但我们的 server 脚本还停在旧 `SCREEN_DIR` 单目录版本，导致 visual brainstorming 教程指向新路径但 server 用旧结构卡死。
+
+- `skills/brainstorming/scripts/server.cjs` — 81 行 cherry-pick 同步
+- `skills/brainstorming/scripts/start-server.sh` — 36 行同步
+- `skills/brainstorming/scripts/stop-server.sh` — 29 行同步
+
+**修复后：所有 visual brainstorming 用户路径解析正常。**
+
+### 🔴 上游同步：v5.1.0 Code Review 整合（PR #30）
+
+上游 v5.1.0 PR #1299 把 reviewer persona + checklist + dispatch 模板整合到单一 `code-reviewer.md` 实现 self-contained，并把 SKILL.md 里的 `superpowers:code-reviewer` 命名子代理引用改成 `general-purpose` Task + 模板路径形式。我们的版本停留在 v5.0.x 拆分式。
+
+- `skills/requesting-code-review/SKILL.md` 改 4 处：3 处 `superpowers:code-reviewer` 引用清零；占位符从 5 个精简到 4 个对齐上游；"执行计划" 集成段从 "每批（3 个任务）后审查" 改为 "每个任务完成后或在自然 checkpoint 审查"（对齐上游 v5.1.0 subagent 节奏调整）
+- `skills/requesting-code-review/code-reviewer.md` 完整重写为 v5.1.0 self-contained 版（H header 6/6 对齐上游）
+
+**修复后：所有走 review 流程的用户得到的指令指向 `general-purpose` Task 而非已废弃的命名子代理。**
+
+### 🔴 上游同步：v5.1.0 worktree 安全修复（PR #28）
+
+上游 v5.1.0 [#991](https://github.com/obra/superpowers/issues/991) 修复了两类 worktree 安全问题：subagent 嵌套创建 + cleanup 误删 harness-managed workspace。
+
+- `skills/using-git-worktrees/SKILL.md` 全面重构：新增 Step 0 检测现有隔离（GIT_DIR/GIT_COMMON + submodule 守卫 + 同意流程）；Step 1 重组为 1a Native Tools + 1b Git Worktree Fallback + 沙盒回退；删除旧"示例工作流"段（含 `/Users/jesse` 硬编码）
+- `skills/finishing-a-development-branch/SKILL.md` 全面重构：新增 Step 2 检测环境（三态表）；旧 Step 2-5 重编号为 3-6；Step 4 新增分离 HEAD 3 选项变体；Step 5 Option 1 重写（MAIN_ROOT cwd safety + merge→verify→cleanup→delete 严格排序）；Step 6 清理范围限定在 `.worktrees/` / `worktrees/` / `~/.config/superpowers/worktrees/`，外部 harness-managed workspace 一律不动
+
+**修复后：subagent 不再嵌套创建 worktree；清理不会误删 harness-managed workspace。**
+
+### 🔴 平台兼容性修复：Windows Cursor hook 回归（PR #30）
+
+`hooks/hooks-cursor.json` 的 command 之前被本地改成直接调 unix shell `./hooks/session-start`，丢失上游的 polyglot wrapper `./hooks/run-hook.cmd session-start`，Windows + Cursor 组合用户 hook 完全不触发。
+
+- 1 行恢复上游 polyglot wrapper
+
+**修复后：Windows Cursor 用户 hook 正常触发。**
+
+### 🆕 防回归基建：CI 自动漂移检测（PR #31）
+
+新增 `scripts/audit.sh` + `.github/workflows/audit.yml`，每次 PR 自动跑 4 类共 90+ 项检查：
+
+1. 静态校验（JSON parse / SKILL.md frontmatter / symlink / hook 可执行性）
+2. Installer 功能（17 款工具装/重装/卸载全跑）
+3. 上游对齐（hooks 4 文件 + brainstorm scripts 3 文件 + 14 翻译 skill 结构层级 + code-reviewer.md self-contained 结构）
+4. 交叉引用（README → docs/ 链接 + skill 间引用 + 装完后 .claude/skills/using-superpowers/SKILL.md 路径解析）
+
+WARN（不阻塞）vs FAIL（阻塞）分级：本次"4 个 P0 漂"事件如果当时有这个 audit 在 CI 跑，PR 阶段就会被拦下。
+
+**未来意义：维护者下次手抖把 `hooks-cursor.json` 改坏 / 上游同步漏一项，CI 立刻拦下。**
+
+### 🔧 工具链小修
+
+- `scripts/sync-plugin-version.js` 加入 `gemini-extension.json`（之前漏掉，导致 gemini extension manifest 卡在 1.1.6 老版本）
+- `package.json` 的 `version` 钩子 git add 列表同步更新
+
+### 安装路径方针澄清
+
+本版本明确：**有官方 plugin marketplace 的工具（Claude Code / Codex CLI / OpenCode / VS Code）首选 marketplace 路径**，npx `superpowers-zh` 主要服务没有 marketplace 的工具（Cursor / Trae / Kiro / Gemini CLI / Hermes / Aider / Antigravity / Windsurf / Qwen / Claw / OpenClaw / DeerFlow 共 13 款）。fork 不再尝试给 marketplace 工具加 npx 路径的"完整支持"——它们走主站路径即可。
+
+### 不在本版本范围
+
+- `executing-plans/SKILL.md` 我们扩写了 105 行中文示例（主动选择，保留——是 fork 的中文优化，非漂移）
+- `using-superpowers/SKILL.md` 的"中国特色技能路由"段（fork 增量，保留）
+- 各 reviewer-prompt.md 翻译差异（结构对齐，纯翻译漂移，无行为 bug）
+- open issues #18/#21/#26/#20（fork 增量需求，按方针延后）
+
+### Refs
+
+- PR #28（worktree 安全修复）
+- PR #30（brainstorm scripts + code-reviewer 整合 + hooks-cursor + SKILL.md 引用）
+- PR #31（audit script + CI workflow）
+- issue #19 跟踪上游 v5.0.6 / v5.1.0 同步 → 关键项目全部覆盖
+
+---
+
 ## v1.3.0 (2026-05-10)
 
 ### 跟上游对齐 (v5.1.0)

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "superpowers-zh",
   "description": "AI 编程超能力中文版 — TDD、调试、代码审查等经过实战验证的工作方法论",
-  "version": "1.1.6",
+  "version": "1.4.0",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superpowers-zh",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "engines": {
     "node": ">=20.0.0"
   },
@@ -11,7 +11,7 @@
     "superpowers-zh": "bin/superpowers-zh.js"
   },
   "scripts": {
-    "version": "node scripts/sync-plugin-version.js && git add .claude-plugin/plugin.json .claude-plugin/marketplace.json .cursor-plugin/plugin.json .codex-plugin/plugin.json"
+    "version": "node scripts/sync-plugin-version.js && git add .claude-plugin/plugin.json .claude-plugin/marketplace.json .cursor-plugin/plugin.json .codex-plugin/plugin.json gemini-extension.json"
   },
   "files": [
     "bin/",

--- a/scripts/sync-plugin-version.js
+++ b/scripts/sync-plugin-version.js
@@ -18,6 +18,7 @@ const TARGETS = [
   { path: '.cursor-plugin/plugin.json',      field: 'version' },
   { path: '.codex-plugin/plugin.json',       field: 'version' },
   { path: '.claude-plugin/marketplace.json', field: 'plugins.0.version' },
+  { path: 'gemini-extension.json',           field: 'version' },
 ];
 
 function buildPattern(field) {


### PR DESCRIPTION
## 你要解决什么问题？

跟 PR #28 + #30 + #31 一起构成 **v1.4.0 的完整内容**——本 PR 只做发布层（版本号 bump + plugin manifest 同步 + release notes），不动任何 skill 内容、不动 installer、不动 hooks。

**为什么需要一个独立的 release PR：** 上游 fork 的发布流程是 "skill/fix PR 单独 merge → release commit 单独 bump version + 写 release notes"（参见 6c1fe58 chore: release v1.3.0 提交模式）。本 PR 严格按此模式走。

## 这个 PR 做了什么改变？

**版本号 1.3.0 → 1.4.0**：

- `package.json` 1.3.0 → 1.4.0
- `.claude-plugin/plugin.json` 1.3.0 → 1.4.0
- `.claude-plugin/marketplace.json` plugins.0.version 1.3.0 → 1.4.0
- `.cursor-plugin/plugin.json` 1.3.0 → 1.4.0
- `.codex-plugin/plugin.json` 1.3.0 → 1.4.0
- `gemini-extension.json` 1.1.6 → 1.4.0（顺带修复长期漂移）

**工具链顺带修复：**

- `scripts/sync-plugin-version.js` 的 TARGETS 加入 `gemini-extension.json` —— 这是 gemini-extension.json 长期卡在 1.1.6 的根因（在 `.version-bump.json` 列了但 sync-plugin-version.js 的 TARGETS 漏掉了）
- `package.json` 的 \`version\` 钩子 git add 列表加上 \`gemini-extension.json\`

**`RELEASE-NOTES.zh.md` 新增 v1.4.0 段（78 行）：**

按"上游同步"性质分组列出本次 release 的 9 项修复：

- 🔴 v5.0.6 brainstorm server 拆分（→ PR #30）
- 🔴 v5.1.0 Code Review 整合（→ PR #30）
- 🔴 v5.1.0 worktree 安全修复（→ PR #28）
- 🔴 Windows Cursor hook 回归修复（→ PR #30）
- 🆕 CI 自动漂移检测基建（→ PR #31）
- 🔧 gemini-extension.json 版本号长期漂移修复（本 PR）

明确标注每项的上游 ref + 本 fork PR 号 + 不在范围的项（executing-plans 扩写、中国特色技能路由等主动选择）。

## 这个改变适合放在核心库中吗？

适合。版本号管理是 release 流程的核心环节，6 个 plugin manifest 全部对齐 + gemini-extension.json 长期漂移修复，对所有走 marketplace / extension 安装的用户都有效。

## 你考虑了哪些替代方案？

1. **把 release 内容塞到 PR #30 里**：违反 fork 的发布流程惯例（chore: release 应该独立 commit）。Pass。
2. **不修 gemini-extension.json，等下个 release**：该文件已经卡在 1.1.6 几个月，趁本 release 一起追上，避免漂移积累。这个 1 行 sync-plugin-version.js 改动 + 1 行 package.json git add 改动，scope 是合理的"顺带修工具链 bug"。
3. **现方案：版本 bump + 工具链修 + release notes 一起** ✓

## 这个 PR 是否包含多个不相关的改变？

否。三件事通过共同性质绑定：**"v1.4.0 release prep"**。版本号 bump 必然牵动 6 个 manifest；gemini-extension.json 的 sync-plugin-version.js 修复正是为了让"版本号 bump"这件事一次性正确完成（否则 gemini-extension 又会被漏掉）。release notes 文档化本次发布内容。

## 已有的 PR
- [x] 我已查看所有已开放和已关闭的 PR，确认没有重复或先前的类似工作
- 相关 PR：
  - **PR #28**（worktree v5.1.0 同步）—— 本 PR release notes 描述的内容之一
  - **PR #30**（P0 漂移 + code-reviewer 整合）—— 本 PR release notes 描述的内容之一
  - **PR #31**（audit script + CI workflow）—— 本 PR release notes 描述的内容之一
  - 历史 PR #23（sync-plugin-version 支持嵌套字段）—— 同类工具链修复，本 PR 是 #23 的延续（#23 加了嵌套路径支持，本 PR 把遗漏的 gemini-extension.json 也加进 TARGETS）

⚠️ **merge 顺序敏感：本 PR 必须最后 merge**（在 #28 / #30 / #31 之后），否则 release notes 引用的 PR 在 git log 里还没出现。

## 测试环境

| 工具 | 工具版本 | 模型 | 模型版本/ID |
|------|---------|------|------------|
| Claude Code | latest | Claude Opus | claude-opus-4-7 |

**本地验证：**

- \`node scripts/sync-plugin-version.js\` 运行后，6 个 manifest 全部 1.4.0 对齐（含 gemini-extension.json，之前卡在 1.1.6）
- \`grep -rn '1.3.0' .claude-plugin/ .cursor-plugin/ .codex-plugin/ gemini-extension.json package.json\` → 无残留
- RELEASE-NOTES.zh.md v1.4.0 段对照 #28 / #30 / #31 的内容，每个修复项都能在 PR 里找到对应 commit

## 评估

不适用 —— **本 PR 是 release prep（版本号 + 工具链 + 文档），不改任何 skill 内容、不影响模型行为**。

## 严格性

- [x] 这不是 skill 内容改变，无需对抗式压力测试
- [x] 没有修改任何精心调优的 skill 内容
- [x] 修改的是 fork 自有版本管理 / release notes

## 人工审核
- [x] 提交前已有人工审核过 diff（8 文件 86 +/7 -）
- [ ] 完整文本 review 待你在 GitHub PR diff 视图 inline 评论

---

## 推荐 merge 顺序

```
1. PR #28（worktree v5.1.0 安全修复）  ←  纯 skill 内容
2. PR #30（P0 漂移 + code-reviewer 整合）  ←  纯 skill 内容
3. PR #31（audit script + CI）  ←  基建独立
4. PR #27（文案漂移）  ←  你定夺，可选
5. PR #34（本 PR：release v1.4.0）  ←  最后做 release commit
6. 你手动：git tag v1.4.0 + git push --tags + npm publish
```