### PR TITLE
feat: add non-blocking auto-update to OpenCode plugin

### DIFF
--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -84,31 +84,34 @@ ${toolMapping}
 
       // ---- (2) Non-blocking auto-update ----
       // Delay 2 seconds then run npx -y superpowers-zh in the background.
-      // All errors are caught silently — never blocks OpenCode startup.
+      // Toast only when skills actually changed or update failed.
       setTimeout(async () => {
+        // Snapshot skills mtime before update
+        const skillsDir = path.join(directory, '.opencode', 'skills');
+        const getMtime = () => {
+          try {
+            const files = fs.readdirSync(skillsDir, { recursive: true });
+            return Math.max(0, ...files.map(f => {
+              try { return fs.statSync(path.join(skillsDir, f)).mtimeMs; } catch { return 0; }
+            }));
+          } catch { return 0; }
+        };
+        const before = getMtime();
+
         try {
-          await execAsync('npx -y superpowers-zh', {
+          await execAsync('npx -y superpowers-zh > /dev/null 2>&1', {
             cwd: directory,
             timeout: 120000,
           });
-          // Notify success (toast failure does NOT affect update result)
-          client.tui.showToast({
-            body: {
-              variant: 'success',
-              title: 'superpowers-zh',
-              message: '中文 Skills 更新完成',
-              duration: 3000,
-            },
-          }).catch(() => {});
+          // Only toast when skills were actually updated
+          if (getMtime() > before) {
+            client.tui.showToast({
+              body: { variant: 'success', title: 'superpowers-zh', message: '中文 Skills 更新完成', duration: 3000 },
+            }).catch(() => {});
+          }
         } catch {
-          // Notify failure (toast failure does NOT throw uncaught exception)
           client.tui.showToast({
-            body: {
-              variant: 'warning',
-              title: 'superpowers-zh 更新',
-              message: '自动更新未成功，可手动执行 npx superpowers-zh',
-              duration: 5000,
-            },
+            body: { variant: 'warning', title: 'superpowers-zh 更新', message: '自动更新未成功，可手动执行 npx superpowers-zh', duration: 5000 },
           }).catch(() => {});
         }
       }, 2000);

--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -1,15 +1,20 @@
 /**
  * Superpowers plugin for OpenCode.ai
  *
- * Injects superpowers bootstrap context via user message transform.
- * Auto-registers skills directory via config hook (no symlinks needed).
+ * Features:
+ * 1. Injects superpowers bootstrap context via user message transform.
+ * 2. Auto-registers skills directory via config hook (no symlinks needed).
+ * 3. Auto-updates superpowers-zh skills on startup (non-blocking).
  */
 
 import path from 'path';
 import fs from 'fs';
+import { exec } from 'child_process';
+import { promisify } from 'util';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const execAsync = promisify(exec);
 
 // Simple frontmatter extraction (avoid dependency on skills-core for bootstrap)
 const extractAndStripFrontmatter = (content) => {
@@ -70,11 +75,43 @@ ${toolMapping}
     // This works because Config.get() returns a cached singleton — modifications
     // here are visible when skills are lazily discovered later.
     config: async (config) => {
+      // ---- (1) Register skills path ----
       config.skills = config.skills || {};
       config.skills.paths = config.skills.paths || [];
       if (!config.skills.paths.includes(superpowersSkillsDir)) {
         config.skills.paths.push(superpowersSkillsDir);
       }
+
+      // ---- (2) Non-blocking auto-update ----
+      // Delay 2 seconds then run npx -y superpowers-zh in the background.
+      // All errors are caught silently — never blocks OpenCode startup.
+      setTimeout(async () => {
+        try {
+          await execAsync('npx -y superpowers-zh', {
+            cwd: directory,
+            timeout: 120000,
+          });
+          // Notify success (toast failure does NOT affect update result)
+          client.tui.showToast({
+            body: {
+              variant: 'success',
+              title: 'superpowers-zh',
+              message: '中文 Skills 更新完成',
+              duration: 3000,
+            },
+          }).catch(() => {});
+        } catch {
+          // Notify failure (toast failure does NOT throw uncaught exception)
+          client.tui.showToast({
+            body: {
+              variant: 'warning',
+              title: 'superpowers-zh 更新',
+              message: '自动更新未成功，可手动执行 npx superpowers-zh',
+              duration: 5000,
+            },
+          }).catch(() => {});
+        }
+      }, 2000);
     },
 
     // Inject bootstrap into the first user message of each session.

--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -83,32 +83,36 @@ ${toolMapping}
       }
 
       // ---- (2) Non-blocking auto-update ----
-      // Delay 2 seconds then run npx -y superpowers-zh in the background.
-      // Toast only when skills actually changed or update failed.
+      // Check remote version, only run npx when a newer version is available.
+      // Toast only on actual update or failure — silent when already latest.
       setTimeout(async () => {
-        // Snapshot skills mtime before update
-        const skillsDir = path.join(directory, '.opencode', 'skills');
-        const getMtime = () => {
-          try {
-            const files = fs.readdirSync(skillsDir, { recursive: true });
-            return Math.max(0, ...files.map(f => {
-              try { return fs.statSync(path.join(skillsDir, f)).mtimeMs; } catch { return 0; }
-            }));
-          } catch { return 0; }
-        };
-        const before = getMtime();
+        const versionFile = path.join(directory, '.opencode', '.superpowers-version');
 
+        // Get remote latest version (silently skip on network error)
+        let remoteVer;
+        try {
+          const { stdout } = await execAsync('npm view superpowers-zh version', { timeout: 10000 });
+          remoteVer = stdout.trim();
+        } catch {
+          return; // Network unavailable, skip silently
+        }
+        if (!remoteVer) return;
+
+        // Compare with locally recorded version
+        let localVer = '';
+        try { localVer = fs.readFileSync(versionFile, 'utf8').trim(); } catch {}
+        if (remoteVer === localVer) return; // Already latest, silent
+
+        // Run update
         try {
           await execAsync('npx -y superpowers-zh > /dev/null 2>&1', {
             cwd: directory,
             timeout: 120000,
           });
-          // Only toast when skills were actually updated
-          if (getMtime() > before) {
-            client.tui.showToast({
-              body: { variant: 'success', title: 'superpowers-zh', message: '中文 Skills 更新完成', duration: 3000 },
-            }).catch(() => {});
-          }
+          fs.writeFileSync(versionFile, remoteVer);
+          client.tui.showToast({
+            body: { variant: 'success', title: 'superpowers-zh', message: '中文 Skills 更新完成', duration: 3000 },
+          }).catch(() => {});
         } catch {
           client.tui.showToast({
             body: { variant: 'warning', title: 'superpowers-zh 更新', message: '自动更新未成功，可手动执行 npx superpowers-zh', duration: 5000 },


### PR DESCRIPTION
## 改动内容

OpenCode 插件启动时自动执行 `npx -y superpowers-zh` 更新 skills。

### 新增功能
- **非阻塞自动更新**：启动后延迟 2 秒后台异步执行更新，不阻塞 OpenCode 启动
- **用户通知**：更新成功/失败通过 TUI toast 通知
- **错误隔离**：更新执行和通知展示独立 catch，互不影响

### 技术细节
- 使用 Node.js 内置 `child_process.exec` + `util.promisify`，零依赖新增
- 2 秒延迟 + 120 秒超时，安全可靠
- `showToast` 失败静默忽略，不误判为更新失败

### 相关 Issue
无

### 自检清单
- [x] 语法检查通过 (`node --check`)
- [x] 非阻塞启动（config 钩子立即返回）
- [x] 错误完全隔离
- [x] 零外部依赖

---
Vibe coding ✨