### PR TITLE
fix(install): 检测落空时不再静默兜底安装到 .claude (#33)

### DIFF
--- a/bin/superpowers-zh.js
+++ b/bin/superpowers-zh.js
@@ -748,18 +748,17 @@ function install(forceToolName, force) {
   }
 
   if (installed === 0) {
-    console.log('  ⚠️  未检测到任何已知的 AI 编程工具。\n');
-    console.log('  如果你使用的是 Cursor、Trae 等工具，请用 --tool 指定：');
-    console.log('    npx superpowers-zh --tool cursor');
-    console.log('    npx superpowers-zh --tool trae\n');
-    console.log('  现在将默认安装到 .claude/skills/（兼容 Claude Code / OpenClaw）\n');
-
-    const dest = resolve(PROJECT_DIR, '.claude', 'skills');
-    mkdirSync(dest, { recursive: true });
-    copyDirSync(SKILLS_SRC, dest);
-    console.log(`  ✅ 默认安装: ${countDirs(dest)} 个 skills -> ${dest}`);
-
-    generateClaudeCodeBootstrap(PROJECT_DIR);
+    // 检测落空时不再静默装 Claude Code —— 否则 Antigravity / Trae 等
+    // 不会在项目里留下检测目录的工具，会被误装成 Claude（见 issue #33）。
+    // 改为明确报错并教用户用 --tool 显式指定。
+    console.log('  ⚠️  未在当前目录检测到任何已知 AI 编程工具的项目标记。\n');
+    console.log('  为避免装错工具，未做任何安装。请用 --tool 显式指定你的工具，例如：\n');
+    console.log('    npx superpowers-zh --tool claude        # Claude Code / Copilot CLI');
+    console.log('    npx superpowers-zh --tool antigravity   # Google Antigravity');
+    console.log('    npx superpowers-zh --tool trae          # Trae');
+    console.log('    npx superpowers-zh --tool cursor        # Cursor\n');
+    console.log(`  全部可用别名：${Object.keys(TOOL_ALIASES).join(', ')}\n`);
+    process.exit(1);
   }
 
   console.log('\n  安装完成！重启你的 AI 编程工具即可生效。\n');


### PR DESCRIPTION
## 解决的问题

修复 #33 —— 在 Antigravity 中安装时被误装成默认工具的文件、且卸载后文件残留。

## 根因

零参数 `npx superpowers-zh` 会自动检测项目里的工具目录。检测不到任何工具时，原本会**静默兜底**安装到 `.claude/skills/`（`bin/superpowers-zh.js` 的 `install()`）。

但 Antigravity / Trae 等工具**不一定会在项目里留下检测目录**（如 `.antigravity/`），所以这些工具的用户跑零参数安装时必然落入兜底分支，被装成默认目标的文件——这正是 #33 报告的「装的不是适配本工具的文件」。

同时，因为文件实际落在 `.claude/` 而非用户预期的目录，用户去预期目录找不到、卸载也对不上，表现为「卸载显示成功但文件还在」。

## 改动

检测落空时**不再静默兜底安装**，改为明确报错并列出 `--tool` 用法后退出，不做任何安装：

- 带 `.claude/` 的真实 Claude Code 项目仍会被自动检测命中，**裸命令安装行为不变**（README 承诺不破）。
- 其它工具用户会看到清晰指引：`npx superpowers-zh --tool antigravity` 等。

## 验证

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 空项目零参数 | 静默装到 `.claude/skills/` | 报错 + 列出 `--tool` 用法，不装任何东西 ✅ |
| 带 `.claude/` 的项目零参数 | 自动检测安装 | 自动检测安装（不变）✅ |
| `--tool antigravity` | 正确安装 | 正确安装（不变）✅ |

三个场景均在本地实测通过。`showHelp` 文案原本就是「检测不到时用 --tool」，与新行为一致，无需改。

Closes #33