### PR TITLE
fix(Antigravity): 修复Antigravity安装引导文件目录错误问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ AI：在开始实现之前，我需要了解几个关键问题：
 | [OpenCode](https://opencode.ai) | CLI | `npx superpowers-zh` | `.opencode/skills/` |
 | [OpenClaw](https://github.com/anthropics/openclaw) | CLI | `npx superpowers-zh` | `skills/` |
 | [Qwen Code](https://tongyi.aliyun.com/lingma) (通义灵码) | IDE 插件 | `npx superpowers-zh` | `.qwen/skills/` |
-| [Antigravity](https://github.com/anthropics/antigravity) | CLI | `npx superpowers-zh` | `.antigravity/skills/` |
+| [Antigravity](https://github.com/anthropics/antigravity) | CLI | `npx superpowers-zh` | `.agents/skills/` |
 | [Claw Code](https://github.com/ultraworkers/claw-code) | CLI (Rust) | `npx superpowers-zh` | `.claw/skills/` |
 | [Qoder](https://qoder.com) (阿里 AI IDE) | IDE | `npx superpowers-zh` | `.qoder/skills/` + `.qoder/rules/` |
 
@@ -170,7 +170,7 @@ cp -r superpowers-zh/skills /your/project/.codex/skills       # Codex CLI
 cp -r superpowers-zh/skills /your/project/.kiro/steering      # Kiro
 cp -r superpowers-zh/skills /your/project/skills/custom       # DeerFlow 2.0
 cp -r superpowers-zh/skills /your/project/.trae/rules         # Trae
-cp -r superpowers-zh/skills /your/project/.antigravity        # Antigravity
+cp -r superpowers-zh/skills /your/project/.agents        # Antigravity
 cp -r superpowers-zh/skills /your/project/.github/superpowers # VS Code (Copilot)
 cp -r superpowers-zh/skills /your/project/skills              # OpenClaw
 cp -r superpowers-zh/skills /your/project/.windsurf/skills   # Windsurf
@@ -207,7 +207,7 @@ cp -r superpowers-zh/skills /your/project/.qoder/skills      # Qoder（阿里 AI
 | Claw Code | `.claw/skills/*/SKILL.md` | Rust 版 CLI agent，兼容 Claude Code 的 SKILL.md 格式 |
 | Qoder | `.qoder/skills/*/SKILL.md` + `.qoder/rules/superpowers-zh.md` | 阿里 AI IDE，自动生成 `trigger: always_on` 的 bootstrap rule |
 
-> **详细安装指南**：[Kiro](docs/README.kiro.md) · [DeerFlow](docs/README.deerflow.md) · [Trae](docs/README.trae.md) · [Antigravity](docs/README.antigravity.md) · [VS Code](docs/README.vscode.md) · [Codex](docs/README.codex.md) · [OpenCode](docs/README.opencode.md) · [OpenClaw](docs/README.openclaw.md) · [Windsurf](docs/README.windsurf.md) · [Gemini CLI](docs/README.gemini-cli.md) · [Aider](docs/README.aider.md) · [Qwen Code](docs/README.qwen.md) · [Hermes Agent](docs/README.hermes.md) · [Qoder](docs/README.qoder.md)
+> **详细安装指南**：[Kiro](docs/README.kiro.md) · [DeerFlow](docs/README.deerflow.md) · [Trae](docs/README.trae.md) · [Antigravity](docs/README.agents.md) · [VS Code](docs/README.vscode.md) · [Codex](docs/README.codex.md) · [OpenCode](docs/README.opencode.md) · [OpenClaw](docs/README.openclaw.md) · [Windsurf](docs/README.windsurf.md) · [Gemini CLI](docs/README.gemini-cli.md) · [Aider](docs/README.aider.md) · [Qwen Code](docs/README.qwen.md) · [Hermes Agent](docs/README.hermes.md) · [Qoder](docs/README.qoder.md)
 
 ### 卸载 / 误装清理（v1.2.1+）
 
@@ -219,7 +219,7 @@ npx superpowers-zh@latest --uninstall
 会做这些：
 
 - 删除所有装过的 skill 目录（`.claude/skills/`、`.trae/skills/` 等）
-- 删除独立 bootstrap 文件（`.trae/rules/superpowers-zh.md`、`.qoder/rules/superpowers-zh.md`、`.antigravity/rules.md`）
+- 删除独立 bootstrap 文件（`.trae/rules/superpowers-zh.md`、`.qoder/rules/superpowers-zh.md`、`.agents/rules.md`）
 - 清理追加到 `CLAUDE.md` / `HERMES.md` / `GEMINI.md` / `CONVENTIONS.md` 里的 superpowers-zh 段，**保留你自己写的内容**
 
 数据安全说明：v1.2.1 起，安装会把追加内容包在 `<!-- superpowers-zh:begin/end -->` 哨兵注释之间，卸载按哨兵精确切除。识别不可靠时跳过 + 警告，**绝不会误删用户内容**。

--- a/bin/superpowers-zh.js
+++ b/bin/superpowers-zh.js
@@ -53,7 +53,7 @@ const TARGETS = [
   { name: 'Kiro',          dir: '.kiro/steering',            detect: '.kiro' },
   { name: 'DeerFlow',      dir: 'skills/custom',             detect: 'deer_flow' },
   { name: 'Trae',          dir: '.trae/skills',              detect: '.trae' },
-  { name: 'Antigravity',   dir: '.antigravity/skills',       detect: '.antigravity' },
+  { name: 'Antigravity',   dir: '.agents/skills',            detect: '.agents' },
   { name: 'VS Code',       dir: '.github/superpowers',       detect: '.github/copilot-instructions.md' },
   { name: 'OpenClaw',      dir: 'skills',                     detect: '.openclaw' },
   { name: 'Windsurf',      dir: '.windsurf/skills',          detect: '.windsurf' },
@@ -204,17 +204,17 @@ function generateAntigravityBootstrap(projectDir) {
 
 ## 可用 Skills
 
-Skills 位于 \`.antigravity/skills/\` 目录，每个 skill 有独立的 \`SKILL.md\` 文件。
+Skills 位于 \`.agents/skills/\` 目录，每个 skill 有独立的 \`SKILL.md\` 文件。
 
 ${skillList}
 
 ## 如何使用
 
-当任务匹配某个 skill 时，读取对应的 \`.antigravity/skills/<skill-name>/SKILL.md\` 并严格遵循其流程。
+当任务匹配某个 skill 时，读取对应的 \`.agents/skills/<skill-name>/SKILL.md\` 并严格遵循其流程。
 `;
 
-  // 写入 .antigravity/rules.md（不覆盖用户已有的 GEMINI.md / AGENTS.md）
-  const rulePath = resolve(projectDir, '.antigravity', 'rules.md');
+  // 写入 .agents/rules.md（不覆盖用户已有的 GEMINI.md / AGENTS.md）
+  const rulePath = resolve(projectDir, '.agents', 'rules.md');
   writeFileSync(rulePath, content, 'utf8');
   console.log(`  ✅ Antigravity: bootstrap rule -> ${rulePath}`);
 }
@@ -521,7 +521,7 @@ function isHomeDir(p) {
 const BOOTSTRAP_DELETE = [
   '.trae/rules/superpowers-zh.md',
   '.qoder/rules/superpowers-zh.md',
-  '.antigravity/rules.md',
+  '.agents/rules.md',
 ];
 const BOOTSTRAP_CLEAN_SECTION = [
   'CLAUDE.md',

--- a/docs/README.antigravity.md
+++ b/docs/README.antigravity.md
@@ -9,14 +9,14 @@ cd /your/project
 npx superpowers-zh
 ```
 
-安装脚本会自动检测 `.antigravity/` 目录并将 skills 复制到该目录。
+安装脚本会自动检测 `.agents/` 目录并将 skills 复制到该目录。
 
 ## 手动安装
 
 ```bash
 git clone https://github.com/jnMetaCode/superpowers-zh.git
-mkdir -p /your/project/.antigravity/skills
-cp -r superpowers-zh/skills/* /your/project/.antigravity/skills/
+mkdir -p /your/project/.agents/skills
+cp -r superpowers-zh/skills/* /your/project/.agents/skills/
 ```
 
 ## 工作原理
@@ -27,7 +27,7 @@ Antigravity 支持多种规则文件格式：
 |------|--------|------|
 | `GEMINI.md` | 最高 | Antigravity 专属规则 |
 | `AGENTS.md` | 中 | 通用规则（Antigravity、Cursor、Claude Code 共享） |
-| `.antigravity/rules.md` | 中 | 项目级规则目录 |
+| `.agents/rules.md` | 中 | 项目级规则目录 |
 | `CLAUDE.md` | 低 | 也会被自动读取 |
 
 ### 推荐配置方式
@@ -37,10 +37,10 @@ Antigravity 支持多种规则文件格式：
 ```markdown
 # GEMINI.md
 
-使用 .antigravity/ 目录下的 superpowers skills 来指导工作流程。
+使用 .agents/ 目录下的 superpowers skills 来指导工作流程。
 优先使用 brainstorming（头脑风暴）开始新任务。
 
-Skills 列表参见 .antigravity/ 目录。
+Skills 列表参见 .agents/ 目录。
 ```
 
 **方式二**：在 `AGENTS.md` 中引用（多工具共享）：
@@ -49,7 +49,7 @@ Skills 列表参见 .antigravity/ 目录。
 # AGENTS.md
 
 本项目使用 superpowers-zh skills 框架。
-Skills 位于 .antigravity/（Antigravity）或 .claude/skills/（Claude Code）目录下。
+Skills 位于 .agents/（Antigravity）或 .claude/skills/（Claude Code）目录下。
 ```
 
 ### 工具映射


### PR DESCRIPTION
## 你要解决什么问题？
Antigravity ide无法使用/命令的问题[issues/50](https://github.com/jnMetaCode/superpowers-zh/issues/50)

## 这个 PR 做了什么改变？
修改Antigravity引导目录.antigravity为.agents，并修改了对应的说明

## 这个改变适合放在核心库中吗？
适合

## 你考虑了哪些替代方案？
仅这一种方案

## 这个 PR 是否包含多个不相关的改变？
没有

## 已有的 PR
- [x] 我已查看所有已开放和已关闭的 PR，确认没有重复或先前的类似工作
+ 相关 PR：

## 测试环境
| 工具（如 Claude Code、Cursor） | 工具版本 | 模型 | 模型版本/ID |
| --- | --- | --- | --- |
| Antigravity | Antigravity IDE Version: 2.0.4 | Gemini  | 3.5 Flash |


## 评估
+ 你（或你的人类搭档）用什么初始提示词开始了导致这个改变的会话？
+ 做出改变后你运行了多少次评估会话？
+ 与改变之前相比，结果有何变化？
### before
<img width="766" height="634" alt="image" src="https://github.com/user-attachments/assets/e26580b7-a28d-4c94-9baf-94b2cfc6175c" />

### after
<img width="875" height="414" alt="image" src="https://github.com/user-attachments/assets/d1cce6ab-9223-4417-bb57-30e7f3b95ca9" />

<img width="777" height="496" alt="image" src="https://github.com/user-attachments/assets/82e16212-4389-4707-bf78-0b52a8d25352" />


## 严格性
- [ ] 如果这是 skills 改变：我使用了 `superpowers:writing-skills` 并完成了对抗性压力测试（在下方粘贴结果）
- [ ] 这个改变经过了对抗性测试，而不仅仅是正常路径
- [ ] 我没有在未经大量评估证明改变是改进的情况下修改精心调整的内容（红旗表格、合理化描述、"人类搭档"用语）

## 人工审核
- [ ] 提交前已有人工审核过完整的 diff

