### PR TITLE
sync(v6): 移除旧全局 worktree 目录引用，对齐上游 v6.0.0

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -189,7 +189,7 @@ WORKTREE_PATH=$(git rev-parse --show-toplevel)
 
 **如果 `GIT_DIR == GIT_COMMON`：** 普通仓库，无 worktree 可清理。结束。
 
-**如果 worktree 路径在 `.worktrees/`、`worktrees/` 或 `~/.config/superpowers/worktrees/` 之下：** 这是 Superpowers 创建的 worktree —— 我们负责清理。
+**如果 worktree 路径在 `.worktrees/` 或 `worktrees/` 之下：** 这是 Superpowers 创建的 worktree —— 我们负责清理。
 
 ```bash
 MAIN_ROOT=$(git -C "$(git rev-parse --git-common-dir)/.." rev-parse --show-toplevel)
@@ -239,7 +239,7 @@ git worktree prune  # 自愈：清理任何过期的注册记录
 **清理 harness 拥有的 worktree**
 
 - **问题：** 移除 harness 创建的 worktree 会造成幻影状态
-- **修复：** 只清理 `.worktrees/`、`worktrees/` 或 `~/.config/superpowers/worktrees/` 下的 worktree
+- **修复：** 只清理 `.worktrees/` 或 `worktrees/` 下的 worktree
 
 **丢弃时不确认**
 

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -35,7 +35,7 @@ BRANCH=$(git branch --show-current)
 git rev-parse --show-superproject-working-tree 2>/dev/null
 ```
 
-**如果 `GIT_DIR != GIT_COMMON`（且不是 submodule）：** 你已经在一个 linked worktree 内。跳到步骤 3（项目设置）。**不要**再创建一个 worktree。
+**如果 `GIT_DIR != GIT_COMMON`（且不是 submodule）：** 你已经在一个 linked worktree 内。跳到步骤 2（项目设置）。**不要**再创建一个 worktree。
 
 按分支状态报告：
 
@@ -48,7 +48,7 @@ git rev-parse --show-superproject-working-tree 2>/dev/null
 
 > "你希望我搭一个隔离的 worktree 吗？它能保护你当前分支不被改动。"
 
-如果用户已声明过偏好，直接遵循，不再询问。如果用户拒绝同意，原地工作并跳到步骤 3。
+如果用户已声明过偏好，直接遵循，不再询问。如果用户拒绝同意，原地工作并跳到步骤 2。
 
 ## 步骤 1：创建隔离工作区
 
@@ -56,7 +56,7 @@ git rev-parse --show-superproject-working-tree 2>/dev/null
 
 ### 1a. 原生 Worktree 工具（首选）
 
-用户已经请求隔离工作区（步骤 0 已获同意）。你是否已经有创建 worktree 的方法？可能是名为 `EnterWorktree`、`WorktreeCreate` 的工具、`/worktree` 命令，或 `--worktree` 标志。如果有，用它，然后跳到步骤 3。
+用户已经请求隔离工作区（步骤 0 已获同意）。你是否已经有创建 worktree 的方法？可能是名为 `EnterWorktree`、`WorktreeCreate` 的工具、`/worktree` 命令，或 `--worktree` 标志。如果有，用它，然后跳到步骤 2。
 
 原生工具自动处理目录放置、分支创建和清理。在你已经有原生工具的情况下使用 `git worktree add`，会创建你的 harness 看不到也无法管理的"幻影状态"。
 
@@ -81,16 +81,7 @@ git rev-parse --show-superproject-working-tree 2>/dev/null
 
    找到就用。如果两者都存在，`.worktrees` 优先。
 
-3. **检查是否存在全局目录：**
-
-   ```bash
-   project=$(basename "$(git rev-parse --show-toplevel)")
-   ls -d ~/.config/superpowers/worktrees/$project 2>/dev/null
-   ```
-
-   找到就用（兼容老的全局路径）。
-
-4. **如果没有其他可参考的信息**，默认用项目根目录下的 `.worktrees/`。
+3. **如果没有其他可参考的信息**，默认用项目根目录下的 `.worktrees/`。
 
 #### 安全验证（仅项目本地目录）
 
@@ -104,16 +95,11 @@ git check-ignore -q .worktrees 2>/dev/null || git check-ignore -q worktrees 2>/d
 
 **为什么关键：** 防止 worktree 内容被意外提交到仓库。
 
-全局目录（`~/.config/superpowers/worktrees/`）无需验证。
-
 #### 创建工作树
 
 ```bash
-project=$(basename "$(git rev-parse --show-toplevel)")
-
 # 根据选定位置确定路径
-# 项目本地：path="$LOCATION/$BRANCH_NAME"
-# 全局：path="~/.config/superpowers/worktrees/$project/$BRANCH_NAME"
+path="$LOCATION/$BRANCH_NAME"
 
 git worktree add "$path" -b "$BRANCH_NAME"
 cd "$path"
@@ -121,7 +107,7 @@ cd "$path"
 
 **沙盒回退：** 如果 `git worktree add` 因权限错误（沙盒拒绝）失败，告诉用户沙盒阻止了 worktree 创建，你将在当前目录原地工作。然后原地运行 setup 和基线测试。
 
-## 步骤 3：项目设置
+## 步骤 2：项目设置
 
 自动检测并运行相应的设置命令：
 
@@ -140,7 +126,7 @@ if [ -f pyproject.toml ]; then poetry install; fi
 if [ -f go.mod ]; then go mod download; fi
 ```
 
-## 步骤 4：验证基线干净
+## 步骤 3：验证基线干净
 
 运行测试确保工作区初始状态干净：
 
@@ -173,7 +159,6 @@ npm test / cargo test / pytest / go test ./...
 | `worktrees/` 存在 | 用它（验证已忽略） |
 | 两者都存在 | 用 `.worktrees/` |
 | 都不存在 | 检查 instructions 文件，再默认 `.worktrees/` |
-| 全局路径存在 | 用它（向后兼容） |
 | 目录未被忽略 | 添加到 .gitignore + 提交 |
 | 创建时权限错误 | 沙盒回退，原地工作 |
 | 基线测试失败 | 报告失败 + 询问 |
@@ -199,7 +184,7 @@ npm test / cargo test / pytest / go test ./...
 ### 假设目录位置
 
 - **问题：** 造成不一致、违反项目约定
-- **修复：** 遵循优先级：现有目录 > 全局历史路径 > instructions 文件 > 默认
+- **修复：** 遵循优先级：明确 instructions > 现有项目本地目录 > 默认
 
 ### 带着失败的测试继续
 
@@ -221,7 +206,7 @@ npm test / cargo test / pytest / go test ./...
 
 - 先跑步骤 0 检测
 - 优先原生工具，其次 git 回退
-- 遵循目录优先级：现有目录 > 全局历史路径 > instructions 文件 > 默认
+- 遵循目录优先级：明确 instructions > 现有项目本地目录 > 默认
 - 项目本地目录验证已忽略
 - 自动检测并运行项目设置
 - 验证测试基线干净


### PR DESCRIPTION
## 你要解决什么问题？

`using-git-worktrees` 和 `finishing-a-development-branch` 两个 skill 仍在引用 `~/.config/superpowers/worktrees/` 这个**全局 worktree 目录**。上游 obra/superpowers 在 **v6.0.0** 已废弃该目录，worktree 统一落到项目内 `.worktrees/`。本 fork 落后于此：agent 按现有中文 skill 行事时，仍会把这个上游已不再创建的路径当作合法的目录选择项和清理目标，造成与上游实际行为不一致的指引。

此外 `using-git-worktrees` 存在既有的步骤编号缺口（`步骤 0,1,3,4`，缺 2），阅读和交叉引用易混。

本改动属于 issue #19（v6 同步追踪）范围内的 worktree 部分。

## 这个 PR 做了什么改变？

从两个 skill 中移除所有 `~/.config/superpowers/worktrees/` 全局目录引用（目录选择分支、安全验证豁免说明、创建代码块、快速参考表行、优先级表述、清理判定）；并把 `using-git-worktrees` 的步骤重新编号为连续的 `0,1,2,3`、校正 3 处步骤交叉引用，使其与上游 v6.0.3 标题结构逐行对齐。

## 这个改变适合放在核心库中吗？

适合。这是对所有用户通用的核心 worktree skill 的上游行为同步，与具体项目/领域/第三方工具无关，不引入任何依赖。

## 你考虑了哪些替代方案？

- **保留全局目录做"向后兼容"**：放弃。上游已删除创建该目录的逻辑，保留只会指引 agent 操作一个不会再生成的路径，是死引用。
- **只删目录、不修步骤编号**：放弃。既然要与上游 v6.0.3 对齐，顺带修正编号缺口可让结构逐行一致、降低后续同步成本；且编号修正是纯文档、无行为风险。

## 这个 PR 是否包含多个不相关的改变？

否。两文件的改动是同一件事——同步上游 v6.0.0 的「移除旧全局 worktree 目录」这一行为变更。步骤重编号是该文件对齐 v6.0.3 结构的附带必要项。

## 已有的 PR

- [x] 我已查看所有已开放和已关闭的 PR，确认没有重复或先前的类似工作
- 相关 PR：**#28**（已合并，「同步上游 v5.1.0 worktree 安全修复」）。#28 引入了 v5.1.0 的 `GIT_DIR/GIT_COMMON` 检测，但保留了 v5.1.0 仍存在的全局目录；本 PR 是其 **v6.0.0 续集**，删除该目录。三个 open PR（#47/#46/#38）均不涉及 worktree。

## 测试环境

| 工具（如 Claude Code、Cursor） | 工具版本 | 模型 | 模型版本/ID |
|-------------------------------|---------|------|------------|
| Claude Code                   | 本会话   | Claude Opus 4.8 | claude-opus-4-8 |

## 评估

本改动是**对上游已发布、已由上游 eval 验证的行为变更的忠实结构同步**，非新增/重塑 agent 行为，因此未单独跑 writing-skills 对抗式 eval。验证手段：

- `scripts/audit.sh`（仓库自带质量审计：frontmatter / 结构层级 / 交叉引用）→ **78 PASS / 0 FAIL**
- 与上游 v6.0.3 原文做标题结构逐行 diff，确认层级对齐；「创建工作树」代码块与上游逐字一致
- 全文扫描确认两文件无 `~/.config/superpowers` 残留；所有"跳到步骤 N"引用均指向存在的步骤
- 两文件 `description` 字段未改 → skill 触发行为不变

## 严格性

- [x] skills 改动：改动为上游行为同步，非新行为设计；用仓库 audit + 与上游结构 diff 验证（见上）。**未**跑 writing-skills 新增对抗 eval，理由如「评估」节所述
- [x] 这个改变经过了结构/一致性核验，而不仅仅是正常路径
- [x] 我没有在未经评估证明的情况下修改精心调整的内容（红旗表格、合理化描述、"人类搭档"用语等均未触碰）

## 人工审核

- [x] 提交前已有人工审核过完整的 diff
