### PR TITLE
feat(kimi): 新增 Kimi Code harness 支持（关 #37，对齐上游 v6.0.0）

### DIFF
--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "superpowers-zh",
+  "version": "1.5.0",
+  "description": "AI 编程超能力中文增强版：头脑风暴、subagent 驱动开发、规划、TDD、调试、代码审查、收尾工作流，附 4 个中文 skills 沉淀。",
+  "author": {
+    "name": "jnMetaCode",
+    "url": "https://github.com/jnMetaCode"
+  },
+  "homepage": "https://github.com/jnMetaCode/superpowers-zh",
+  "repository": "https://github.com/jnMetaCode/superpowers-zh",
+  "license": "MIT",
+  "keywords": [
+    "brainstorming",
+    "subagent-driven-development",
+    "skills",
+    "planning",
+    "tdd",
+    "debugging",
+    "code-review",
+    "workflow",
+    "chinese",
+    "中文"
+  ],
+  "skills": "./skills/",
+  "sessionStart": {
+    "skill": "using-superpowers"
+  },
+  "skillInstructions": "Kimi Code tool mapping for Superpowers skills:\n\n- When a Superpowers skill says to ask the user, ask clarifying questions, ask one question at a time, present multiple-choice options, use the terminal for a question, or wait for the user's choice, call Kimi Code's `AskUserQuestion` tool. Do not render those choices as plain assistant text unless `AskUserQuestion` is unavailable or the session is in auto permission mode.\n- For `AskUserQuestion`, provide 1 question with 2-4 concrete options when possible. Put the recommended option first and suffix its label with `(Recommended)`.\n- When a Superpowers skill refers to `TodoWrite`, use Kimi Code's `TodoList` tool.\n- When a Superpowers skill says `Task tool (general-purpose)` or asks you to dispatch an implementer/reviewer subagent, use Kimi Code's `Agent` tool with a Kimi subagent type. Do not pass `general-purpose` as `subagent_type`.\n- For implementation, code review, spec review, quality review, and filled Superpowers subagent prompt templates, call `Agent` with `subagent_type: \"coder\"`, paste the fully filled prompt into `prompt`, and provide a short `description`.\n- For read-only codebase exploration that would take several searches, use `Agent` with `subagent_type: \"explore\"`.\n- For read-only planning or architecture design, use `Agent` with `subagent_type: \"plan\"`.\n- Keep dependent Superpowers subagent steps sequential. Use multiple `Agent` calls, or `run_in_background: true` only when the work is independent and background agents are available.\n- When a Superpowers skill refers to the `Skill` tool, use Kimi Code's native `Skill` tool.\n- Use Kimi Code's `Read`, `Write`, `Edit`, `Bash`, `Grep`, `Glob`, `FetchURL`, `WebSearch`, and MCP tools by their actual exposed names.\n- When a skill asks to search file contents, use `Grep`; when it asks to find files by path or pattern, use `Glob`; when it asks to fetch a URL, use `FetchURL`; when it asks to search the web, use `WebSearch`.",
+  "interface": {
+    "displayName": "Superpowers 中文版",
+    "shortDescription": "面向编程 agent 的规划、TDD、调试、交付工作流（中文增强版）",
+    "longDescription": "用 Superpowers 中文版引导 agent 完成头脑风暴、实现规划、测试驱动开发、系统化调试、并行执行、代码审查与分支收尾。在上游 obra/superpowers 之上叠加 4 个中国原创 skill 与多工具适配。",
+    "developerName": "jnMetaCode",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/jnMetaCode/superpowers-zh"
+  }
+}

--- a/.version-bump.json
+++ b/.version-bump.json
@@ -4,6 +4,7 @@
     { "path": ".claude-plugin/plugin.json", "field": "version" },
     { "path": ".cursor-plugin/plugin.json", "field": "version" },
     { "path": ".codex-plugin/plugin.json", "field": "version" },
+    { "path": ".kimi-plugin/plugin.json", "field": "version" },
     { "path": ".claude-plugin/marketplace.json", "field": "plugins.0.version" },
     { "path": "gemini-extension.json", "field": "version" }
   ],

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ cp -r superpowers-zh/skills /your/project/.qoder/skills      # Qoder（阿里 AI
 | Claw Code | `.claw/skills/*/SKILL.md` | Rust 版 CLI agent，兼容 Claude Code 的 SKILL.md 格式 |
 | Qoder | `.qoder/skills/*/SKILL.md` + `.qoder/rules/superpowers-zh.md` | 阿里 AI IDE，自动生成 `trigger: always_on` 的 bootstrap rule |
 
-> **详细安装指南**：[Kiro](docs/README.kiro.md) · [DeerFlow](docs/README.deerflow.md) · [Trae](docs/README.trae.md) · [Antigravity](docs/README.antigravity.md) · [VS Code](docs/README.vscode.md) · [Codex](docs/README.codex.md) · [OpenCode](docs/README.opencode.md) · [OpenClaw](docs/README.openclaw.md) · [Windsurf](docs/README.windsurf.md) · [Gemini CLI](docs/README.gemini-cli.md) · [Aider](docs/README.aider.md) · [Qwen Code](docs/README.qwen.md) · [Hermes Agent](docs/README.hermes.md) · [Qoder](docs/README.qoder.md)
+> **详细安装指南**：[Kiro](docs/README.kiro.md) · [DeerFlow](docs/README.deerflow.md) · [Trae](docs/README.trae.md) · [Antigravity](docs/README.antigravity.md) · [VS Code](docs/README.vscode.md) · [Codex](docs/README.codex.md) · [OpenCode](docs/README.opencode.md) · [OpenClaw](docs/README.openclaw.md) · [Windsurf](docs/README.windsurf.md) · [Gemini CLI](docs/README.gemini-cli.md) · [Aider](docs/README.aider.md) · [Qwen Code](docs/README.qwen.md) · [Hermes Agent](docs/README.hermes.md) · [Qoder](docs/README.qoder.md) · [Kimi Code](docs/README.kimi.md)
 
 ### 卸载 / 误装清理（v1.2.1+）
 

--- a/docs/README.kimi.md
+++ b/docs/README.kimi.md
@@ -1,0 +1,86 @@
+# Superpowers 中文版 · Kimi Code 指南
+
+在 [Kimi Code](https://github.com/MoonshotAI/kimi-code) 上使用 superpowers-zh 的完整说明。
+
+## 安装
+
+superpowers-zh 通过 Kimi Code 的插件清单 `.kimi-plugin/plugin.json` 集成，**直接指向仓库现有的 `skills/` 目录**——不复制 skill、不建 symlink、不装 hook、无任何运行时依赖。
+
+打开插件管理器：
+
+```text
+/plugins
+```
+
+如果 Kimi 插件市场已收录，进入 `Marketplace` > `Superpowers 中文版` 安装即可。
+
+也可以直接从本仓库安装：
+
+```text
+/plugins install https://github.com/jnMetaCode/superpowers-zh
+```
+
+如需验证尚未发布的改动，显式指定分支：
+
+```text
+/plugins install https://github.com/jnMetaCode/superpowers-zh/tree/main
+```
+
+Kimi Code 在**新会话**才会应用插件变更。安装、更新、启用、禁用或重载插件后，用 `/new` 开一个新会话。
+
+## 工作原理
+
+Kimi 插件清单位于 `.kimi-plugin/plugin.json`，做三件事：
+
+1. 把 Kimi Code 指向仓库现有的 `skills/` 目录；
+2. 通过 `sessionStart.skill` 在会话开始时加载 `using-superpowers`（这是让 skill 在恰当时机自动触发的关键）；
+3. 通过 `skillInstructions` 提供 Kimi 专属的工具映射。
+
+## 工具映射
+
+skill 内容描述的是「动作」而非写死某个运行时的工具名。在 Kimi Code 上它们对应到：
+
+- 「向用户提问」/「问澄清问题」/「给出多选项」→ `AskUserQuestion`
+- 「创建待办」/「在待办清单中标记完成」→ `TodoList`
+- 「分派子智能体」/「Task tool (general-purpose)」→ `Agent`（用 Kimi 的 subagent 类型，如 `coder`/`explore`/`plan`，**不要**传 `general-purpose`）
+- 「调用某个 skill」→ Kimi Code 原生 `Skill` 工具
+- 「读文件」/「写文件」/「改文件」→ `Read` / `Write` / `Edit`
+- 「跑 shell 命令」→ `Bash`
+- 「搜索文件内容」→ `Grep`
+- 「按路径/模式找文件」→ `Glob`
+- 「抓取 URL」→ `FetchURL`
+- 「联网搜索」→ `WebSearch`
+
+完整映射写在清单的 `skillInstructions` 字段里，由 Kimi 在运行时读取。
+
+## 更新
+
+用 Kimi Code 的插件管理器：
+
+```text
+/plugins
+```
+
+选中 Superpowers 中文版更新，更新后用 `/new` 开新会话。
+
+## 排错
+
+### 插件没加载
+
+1. 跑 `/plugins info superpowers-zh` 看诊断信息；
+2. 确认插件已启用；
+3. 安装或更新后用 `/new` 开新会话。
+
+### 直接 GitHub 安装装到了旧版本
+
+对于裸仓库 URL，Kimi Code 会装最新的 GitHub release（若存在）。要在下一个 release 前测试未发布的改动，显式指定分支：
+
+```text
+/plugins install https://github.com/jnMetaCode/superpowers-zh/tree/main
+```
+
+### skill 不触发
+
+1. 用 `/plugins info superpowers-zh` 确认插件已启用；
+2. 用 `/new` 开新会话；
+3. 试验收提示词：`我们来做个 react todo list`。集成正常的话，会在写任何代码之前先加载 `brainstorming`。

--- a/scripts/sync-plugin-version.js
+++ b/scripts/sync-plugin-version.js
@@ -17,6 +17,7 @@ const TARGETS = [
   { path: '.claude-plugin/plugin.json',      field: 'version' },
   { path: '.cursor-plugin/plugin.json',      field: 'version' },
   { path: '.codex-plugin/plugin.json',       field: 'version' },
+  { path: '.kimi-plugin/plugin.json',        field: 'version' },
   { path: '.claude-plugin/marketplace.json', field: 'plugins.0.version' },
   { path: 'gemini-extension.json',           field: 'version' },
 ];

--- a/tests/kimi/run-tests.sh
+++ b/tests/kimi/run-tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+bash "$SCRIPT_DIR/test-plugin-manifest.sh"

--- a/tests/kimi/test-plugin-manifest.sh
+++ b/tests/kimi/test-plugin-manifest.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MANIFEST="$REPO_ROOT/.kimi-plugin/plugin.json"
+
+python3 - "$MANIFEST" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+def assert_equal(actual, expected, label):
+    if actual != expected:
+        raise AssertionError(f"{label}: expected {expected!r}, got {actual!r}")
+
+def assert_present(text, needle, label):
+    if needle not in text:
+        raise AssertionError(f"{label}: missing {needle!r}")
+
+assert_equal(manifest.get("name"), "superpowers-zh", "plugin name")
+assert_equal(manifest.get("skills"), "./skills/", "skills path")
+assert_equal(
+    manifest.get("sessionStart", {}).get("skill"),
+    "using-superpowers",
+    "sessionStart.skill",
+)
+
+instructions = manifest.get("skillInstructions")
+if not isinstance(instructions, str) or not instructions.strip():
+    raise AssertionError("skillInstructions must be a non-empty string")
+
+for token in [
+    "AskUserQuestion",
+    "TodoList",
+    "Agent",
+    "Skill",
+    "Read",
+    "Write",
+    "Edit",
+    "Bash",
+    "Grep",
+    "Glob",
+    "FetchURL",
+    "WebSearch",
+]:
+    assert_present(instructions, token, "skillInstructions")
+
+version_config = json.loads(
+    (manifest_path.parents[1] / ".version-bump.json").read_text(encoding="utf-8")
+)
+version_entries = version_config.get("files")
+if not isinstance(version_entries, list):
+    raise AssertionError(".version-bump.json must contain files list")
+
+if not any(
+    entry.get("path") == ".kimi-plugin/plugin.json" and entry.get("field") == "version"
+    for entry in version_entries
+    if isinstance(entry, dict)
+):
+    raise AssertionError(
+        ".version-bump.json must update .kimi-plugin/plugin.json version"
+    )
+
+unsupported_fields = [
+    "tools",
+    "commands",
+    "hooks",
+    "apps",
+    "inject",
+    "configFile",
+    "config_file",
+    "bootstrap",
+]
+present_unsupported = sorted(field for field in unsupported_fields if field in manifest)
+if present_unsupported:
+    raise AssertionError(
+        "unsupported Kimi runtime fields present: "
+        + ", ".join(present_unsupported)
+    )
+
+print("Kimi plugin manifest looks good")
+PY


### PR DESCRIPTION
## 你要解决什么问题？

issue **#37**：Kimi Code（国内主流编程 agent 之一）已支持 Skills 能力，但 superpowers-zh 此前没有原生集成，Kimi 用户无法像 Claude Code / Cursor 等那样开箱使用。上游 obra/superpowers 已在 **v6.0.0** 用插件清单模型原生支持 Kimi Code，本 fork 落后于此。

## 这个 PR 做了什么改变？

为 Kimi Code 新增插件清单 `.kimi-plugin/plugin.json`（指向现有 `skills/`、`sessionStart` 自动加载 `using-superpowers`、`skillInstructions` 提供 Kimi 工具映射），接入版本同步，并补中文安装文档与清单结构测试。

## 这个改变适合放在核心库中吗？

适合——这是为新 harness（Kimi Code）添加支持，正是 CLAUDE.md 中明确允许进入 core 的类别（"新 harness 支持"）。不引入运行时依赖。

## 你考虑了哪些替代方案？

- **改 npx 安装器加 `--tool kimi`**：放弃。Kimi 走插件清单模型（与 Claude Code plugin 同类），通过 `/plugins install <repo>` 直接读取仓库 `skills/`，**不需要复制 skill**。fork 的安装器是面向"需要把 skills 复制进工具目录"的 harness，对 Kimi 不适用——加进去反而是错误抽象。这也与上游 v6.0.0 的集成方式一致。
- **重写一套 Kimi 专属工具映射（中文）**：放弃。`skillInstructions` 引用的是 Kimi 真实工具名（`AskUserQuestion`/`Agent`/`Grep` 等，本就是英文），保留上游经过验证的权威英文映射可避免破坏工具名解析。

## 这个 PR 是否包含多个不相关的改变？

否。全部围绕"新增 Kimi Code 支持"这一件事：清单 + 版本同步接入（清单要随版本号同步）+ 文档（README 链接 + 安装指南）+ 测试。彼此直接依赖。

## 已有的 PR

- [x] 我已查看所有已开放和已关闭的 PR，确认没有重复或先前的类似工作
- 相关 PR：未找到处理 Kimi Code 集成的 PR。三个 open PR（#47 数仓 skill / #46 Atlas Cloud / #38 OpenCode 自动更新）均与 Kimi 无关。本 PR 属同批 v6 同步（参见 #57 worktree、#58 brainstorm/hooks），文件不重叠。

## 测试环境

| 工具（如 Claude Code、Cursor） | 工具版本 | 模型 | 模型版本/ID |
|-------------------------------|---------|------|------------|
| Claude Code                   | 本会话   | Opus 4.8 | claude-opus-4-8 |

> 说明：Kimi Code 内的 skill 实际自动触发未在本 PR 中验证——本会话无 Kimi Code 环境。清单结构严格对齐上游 v6.0.0 已验证的集成方式，且通过下列结构测试。这与本 fork 其它 harness 适配的验证边界一致。

## 评估

新 harness 的清单/文档/测试（非 skill 行为塑造内容），用结构测试 + 静态审计验证：

- `bash tests/kimi/run-tests.sh` **通过**（校验 name=`superpowers-zh`、`skills=./skills/`、`sessionStart.skill=using-superpowers`、`skillInstructions` 含全部 12 个工具映射 token、版本同步条目存在、无 Kimi 不支持的字段）
- `.kimi-plugin/plugin.json` 为合法 JSON
- 版本同步**双机制**（`.version-bump.json` + `scripts/sync-plugin-version.js`）均含 `.kimi-plugin/plugin.json` 条目
- `scripts/audit.sh` 静态校验 **0 FAIL**；`README.md` → `docs/README.kimi.md` 链接可解析

## 严格性

- [x] 非 skill 行为措辞改动（新 harness 清单/文档/测试）；用结构测试 + 审计验证（见上）
- [x] 清单结构经测试验证，覆盖必需字段与"不应出现的字段"两类断言
- [x] 未触碰任何精心调优的行为内容（红旗表、合理化列表、"人类搭档"用语）

## 人工审核

- [x] 提交前已有人工审核过完整的 diff
