### PR TITLE
fix(ci): 部署前确保 Cloudflare Pages 项目存在（修复首次部署 Project not found）

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -25,6 +25,16 @@ jobs:
           node-version: 20
       - name: Build site
         run: node site/build.mjs
+      # 首次部署前确保 Pages 项目存在（wrangler pages deploy 不会自动创建）。
+      # 幂等：项目已存在时创建命令报错，由 || 兜住继续。token 需 Pages:Edit 权限。
+      - name: Ensure Pages project exists
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@3 pages project create superpowers-zh-site \
+            --production-branch main \
+            || echo "项目已存在或创建跳过，继续部署"
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
         with:


### PR DESCRIPTION
首次部署因 `Project not found` 失败——`wrangler pages deploy` 不自动建项目。新增幂等的 `wrangler pages project create` 步骤，用已配置的 secret 自动建项目，CI 全自动完成建项目+部署。

关联 #61（官网）。