### PR TITLE
去重：删正文里重复的免费配套学习行（顶部标记块已有）

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ Chinese community edition of [superpowers](https://github.com/obra/superpowers) 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://makeapullrequest.com)
 
-> 📖 **免费配套学习** → [从零学会 AI 编程](https://aiolaola.com/)：180 节免费实操课 + 《AI 编程实战三卷书》在线阅读 + 实战社区 · superpowers 装好后配上方法论效率翻倍 · 永久免费
-
 ### 📊 项目规模
 
 | 📦 翻译 Skills | 🇨🇳 中国特色 Skills | 🤖 支持工具 |


### PR DESCRIPTION
顶部 `aiolaola:start/end` 标记块已是正式版；正文里那条旧的同款「免费配套学习」行重复，删掉。仅删 1 处重复，标记块不动。