### PR TITLE
交流段：公众号二维码改左右紧凑布局

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,14 +277,24 @@ npx superpowers-zh@latest --uninstall
 
 ## 交流 · Community
 
-微信公众号 **「AI不止语」**（微信搜索 `AI_BuZhiYu`）— 技术问答 · 项目更新 · 实战文章
+<table>
+<tr>
+<td width="170" align="center">
+<img src="assets/qr-wechat.jpg" width="150" alt="微信公众号 AI不止语 二维码"><br>
+<sub>微信扫码关注</sub>
+</td>
+<td>
 
-<img src="assets/qr-wechat.jpg" width="180" alt="微信公众号 AI不止语 二维码">
+微信公众号 **「AI不止语」**（微信搜索 `AI_BuZhiYu`）— 技术问答 · 项目更新 · 实战文章
 
 | 渠道 | 加入方式 |
 |------|---------|
 | QQ 2群 | [点击加入](https://qm.qq.com/q/EeNQA9xCxy)（群号 1071280067） |
 | 微信群 | 关注公众号后回复「群」获取入群方式 |
+
+</td>
+</tr>
+</table>
 
 ---
 


### PR DESCRIPTION
「交流」段二维码改成左右布局(二维码在左、公众号文字+渠道表在右)，更紧凑、省竖向空间。原渠道内容全保留。