### PR TITLE
fix(test): opencode setup.sh 不再拷不存在的 lib/

### DIFF
--- a/tests/opencode/setup.sh
+++ b/tests/opencode/setup.sh
@@ -13,8 +13,9 @@ export XDG_CONFIG_HOME="$TEST_HOME/.config"
 export OPENCODE_CONFIG_DIR="$TEST_HOME/.config/opencode"
 
 # Install plugin to test location
+# 注：本 fork 的 opencode 插件（superpowers.js）自包含、仅读取 ../../skills，
+# 不依赖上游的 lib/（fork 无此目录），故不拷 lib。
 mkdir -p "$HOME/.config/opencode/superpowers"
-cp -r "$REPO_ROOT/lib" "$HOME/.config/opencode/superpowers/"
 cp -r "$REPO_ROOT/skills" "$HOME/.config/opencode/superpowers/"
 
 # Copy plugin directory


### PR DESCRIPTION
陈旧测试修复：setup.sh 从上游照搬了 cp lib，但 fork 无 lib/，导致 opencode 测试套件飘红。fork 插件不依赖 lib，删除该拷贝。验证 STATUS: PASSED。