### PR TITLE
fix(site): HTML no-store 防边缘缓存

### DIFF
--- a/site/build.mjs
+++ b/site/build.mjs
@@ -648,7 +648,7 @@ function build() {
     '  Referrer-Policy: no-referrer\n' +
     '  Cross-Origin-Opener-Policy: same-origin\n' +
     '  Permissions-Policy: geolocation=(), microphone=(), camera=()\n' +
-    '  Cache-Control: public, max-age=0, must-revalidate\n' +
+    '  Cache-Control: no-store\n' +
     '/assets/*\n  Cache-Control: public, max-age=31536000, immutable\n' +
     '/styles.css\n  Cache-Control: public, max-age=31536000, immutable\n' +
     '/app.js\n  Cache-Control: public, max-age=31536000, immutable\n');


### PR DESCRIPTION
尝试用 no-store（强于 max-age=0）让 Cloudflare 不缓存 HTML，绕过 zone Browser Cache TTL=4h 的覆盖。版本化资源仍 immutable。