### PR TITLE
docs(brainstorm): 视觉伴侣补充 Copilot CLI 服务器启动说明

### DIFF
--- a/skills/brainstorming/visual-companion.md
+++ b/skills/brainstorming/visual-companion.md
@@ -70,6 +70,15 @@ scripts/start-server.sh --project-dir /path/to/project
 scripts/start-server.sh --project-dir /path/to/project
 ```
 
+**Copilot CLI：**
+```bash
+# 用后台 shell 会话启动，让服务器跨会话轮次常驻、并立即交回控制权：
+# 有 bash 工具就设 async: true，用 powershell 工具就设 detach: true。
+# 脚本是 .sh，请经 bash 运行（PowerShell 环境下走 Git Bash）。
+# 结束后运行 scripts/stop-server.sh 收尾。
+scripts/start-server.sh --project-dir /path/to/project --foreground
+```
+
 **Gemini CLI：**
 ```bash
 # 使用 --foreground 并在 shell 工具调用上设置 is_background: true，


### PR DESCRIPTION
## 你要解决什么问题？

在 Copilot CLI（Windows，版本 1.0.69-1）上使用 brainstorming 的视觉伴侣时，`skills/brainstorming/visual-companion.md` 的"按平台启动服务器"一节列出了 Claude Code / Codex / Gemini CLI / 其他环境，但**没有 Copilot CLI 条目**（上游 obra/superpowers 是有的）。

缺少专属指引时，agent 即兴用**阻塞式（attached / 前台）**命令启动了常驻的 `node server.cjs`。由于该 web server 永不返回，Copilot CLI 的状态栏**跨多个对话轮次一直停在 "working"**、对话不回到 idle（用户仍能插话，但状态永不结束）。同时留下 2 个孤儿 server 进程运行了约 3 小时。

## 这个 PR 做了什么改变？

在 `visual-companion.md` 的分平台启动一节补充 "Copilot CLI" 段：指导 agent 用 `--foreground` + Copilot CLI 的**后台/异步 shell 模式**启动，使 server 常驻后台、跨轮次存活，同时工具调用立即返回（CLI 回到 idle）；收尾用 `scripts/stop-server.sh` 停止。单文件、单段落。

## 这个改变适合放在核心库中吗？

适合。本项目 README/描述均声明支持 Copilot CLI，且 `visual-companion.md` 本就按平台给出启动指引——独缺 Copilot CLI。这是核心 brainstorming skill 的基础设施，惠及所有使用 Copilot CLI 视觉伴侣的用户；无第三方依赖、非项目/领域专属。

## 你考虑了哪些替代方案？

- **改 `server.cjs` / `start-server.sh` 生命周期**：否决——server 后台常驻是期望行为（用户需要随时查看看板），本问题纯粹是缺启动指引。
- **只写泛化描述、不点名后台机制**：否决——本文件其他平台段都点名了各自的后台标志（Claude Code 的 `run_in_background: true`、Gemini 的 `is_background: true`），点名更利于 agent 正确执行、也与本文件风格一致。故本段同样点名 bash 工具 `async: true`、powershell 工具 `detach: true`，并说明 `.sh` 经 bash 运行（PowerShell 下走 Git Bash）；清理指向 `stop-server.sh`。
- **逐字镜像上游（含 `--open`、英文 `mode:"async"`）**：否决——本 fork 全局省略 `--open`，且 `copilot-tools.md` 用 `async: true`；逐字镜像反而与 fork 约定冲突。

## 这个 PR 是否包含多个不相关的改变？

否。单文件、单段落新增。两个相关但独立的发现（Windows 孤儿 server bug、Copilot CLI powershell/bash 工具不匹配）已**另行开 issue**，不捆绑进本 PR。

## 已有的 PR

- [x] 我已查看所有已开放和已关闭的 PR，确认没有重复或先前的类似工作
- 相关 PR：**#30**（v5 修视觉 brainstorm 脚本挂起，问题不同）、**#58**（v6 对齐上游安全模型/hooks，**未**改动 `visual-companion.md`）。二者均未新增 Copilot CLI 启动段，故本 PR 不重复。

## 测试环境

| 工具 | 工具版本 | 模型 | 模型版本/ID |
|---|---|---|---|
| GitHub Copilot CLI | 1.0.69-1 | Claude Opus 4.8 | claude-opus-4.8 |

（Windows；Node v24.17.0；Git bash 存在）

## 评估

- **触发本次改动的初始 session**：在 Copilot CLI / Windows 上用 brainstorming 视觉伴侣（一次决策头脑风暴），观察到 CLI 长时间卡在 "working"，并遗留 2 个孤儿 server（其一端口 51796，运行约 3h）。
- **实测 before/after（真机 Windows）**：
  - **attached（复现 bug）**：前台启动 `node server.cjs` ≥15s 不返回（会一直占住整轮 → 卡 working）。
  - **background（修复）**：detached 启动约 **0.04s 返回**，server 存活至新开的 shell（跨轮次），带 key 的 URL 返回 **200**、无 key 返回 **403**。
  - **完整看板闭环**：写入 HTML 片段 → 服务端 200 且被 frame 模板包裹 → 用 Playwright 真实点击 → 事件写入 `state/events`，全部通过。
- **指令跟随验证（定稿文案）**：让全新 agent（Claude Opus 4.8、GPT-5.5）在仅阅读本段、不予提示的情况下执行启动，两者均正确地以后台方式（`powershell` 工具 `detach: true`，经 Git Bash 跑 `--foreground`）启动、调用立即返回、`200`/`403` 符合预期并自行清理。
- **说明**：本改动是分平台**启动指引**（程序性文档），未改动行为塑造类内容（未动 Red Flags 表 / 合理化列表 / "human partner" 措辞）。

## 严格性

- [ ] （不适用）本改动非行为塑造类 skill 措辞改动，故未使用 `superpowers:writing-skills` 跑对抗压测；改以上述真机 before/after 实测作为证据。
- [x] 这个改变经过了对抗性测试（多模型对抗审查 + 4 项真机 E2E），而不仅仅是正常路径
- [x] 我没有在未经大量评估证明改变是改进的情况下修改精心调整的内容

## 人工审核

- [x] 提交前已有人工审核过完整的 diff
