### PR TITLE
docs: 补全 v1.7.0 release note

### DIFF
--- a/RELEASE-NOTES.zh.md
+++ b/RELEASE-NOTES.zh.md
@@ -6,7 +6,23 @@
 
 ---
 
-## v1.7.0 (2026-07-12)
+## v1.7.0 (2026-07-13)
+
+### 🆕 新增两款国产 IDE 工具支持（工具数 18 → 20）
+
+- **CodeBuddy**（腾讯 AI IDE，关 #18 / #75）：`.codebuddy/skills/` + `CODEBUDDY.md` bootstrap，加载机制类似 Claude Code。仅项目级（用户级加载路径未证实，暂不做全局）。
+- **华为云码道 CodeArts**（关 #20）：`.codeartsdoer/skills/`，**skills-only** 适配（其 bootstrap/指令文件约定未证实，靠 CodeArts 自身 skill 发现；docs 已说明，不自动触发可手动点名 skill）。
+- 两者均**逐一核对配置来源**（owner 核实 / 用户实测），不臆造无效路径。工具计数在 README / 站点 / package / FAQ / audit 全量同步。
+
+### 🌐 官网 + README 多语言（新增繁体）
+
+- **官网**（#100）重构为 `LANGS` 语言列表驱动，新增**繁体中文站**（zh-Hant）：63 页（3 语言 × (首页 + 20 skill 详情)），语言切换器 / hreflang / sitemap 齐全；以后加语言只需加一项 + 一个翻译对象。
+- **README**（#101）加语言切换栏，新增完整 `README.zh-Hant.md`（353 行对齐，台港自然术语）。
+- 繁体均**手写**（台港术语：程式碼 / 專案 / 除錯 / 全域 / 檔案 等），不引入 OpenCC 依赖。日文按定位不纳入本仓库（应作独立 `superpowers-ja`）。
+
+### 🧹 官网下架赞助商展示
+
+- 移除官网与 README 的赞助商板块（含 5Cookie Code 展示卡 / logo / 样式 / 资源），仅保留一行赞助联系方式；官网切自定义域名 `sp.aiolaola.com`。
 
 ### 🌍 全局安装（关 #21）
 


### PR DESCRIPTION
## 你要解决什么问题？
v1.7.0 已发布到 npm（含 CodeBuddy #98、CodeArts #99、官网/README 繁体 #100/#101、赞助商下架），但 `RELEASE-NOTES.zh.md` 的 1.7.0 条目只记了全局安装 + star 刷新，changelog 不完整。

## 这个 PR 做了什么改变？
补全 1.7.0 条目：新增两款国产工具（CodeBuddy/CodeArts）、官网+README 繁体多语言、赞助商下架三节；日期改为实际发布日 07-13。

## 这个改变适合放在核心库中吗？
适合，纯 changelog 文档修正。

## 你考虑了哪些替代方案？
无——就是补文档准确性。

## 这个 PR 是否包含多个不相关的改变？
否，单一：补 1.7.0 release note。

## 已有的 PR
- [x] 已查重，无重复
- 相关：#98 #99 #100 #101（本次 1.7.0 所含）

## 测试环境
| 工具 | 版本 | 模型 |
|---|---|---|
| 文档 | — | Opus 4.8 |

## 评估
纯文档，无行为影响。audit 不受影响。

## 严格性
- [x] 非 skills 改动（纯 changelog）
- [x] 内容与已合并 PR 核对一致
- [x] 未改行为塑造内容

## 人工审核
- [x] 人类搭档已 review