### PR TITLE
fix: 统一中国特色技能的自动触发说明，与 using-superpowers 路由规则保持一致

### DIFF
--- a/skills/chinese-code-review/SKILL.md
+++ b/skills/chinese-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chinese-code-review
-description: 中文 review 沟通参考——话术模板、分级标注（必须修复/建议修改/仅供参考）、国内团队常见反模式应对。仅在用户显式 /chinese-code-review 时调用，不要根据上下文自动触发。
+description: 中文 review 沟通参考——话术模板、分级标注（必须修复/建议修改/仅供参考）、国内团队常见反模式应对。检测到代码审查场景且团队使用中文沟通时，必须优先调用此技能（与 requesting-code-review 等流程技能叠加使用，不互斥）；用户显式 /chinese-code-review 时同样调用；除这两种情况外，不要仅因为对话使用中文就依据上下文自动触发。
 version: "1.0.0"
 license: MIT
 metadata:

--- a/skills/chinese-commit-conventions/SKILL.md
+++ b/skills/chinese-commit-conventions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chinese-commit-conventions
-description: 中文 commit 与 changelog 配置参考——Conventional Commits 中文适配、commitlint/husky/commitizen 中文模板、conventional-changelog 中文配置。仅在用户显式 /chinese-commit-conventions 时调用，不要根据上下文自动触发。
+description: 中文 commit 与 changelog 配置参考——Conventional Commits 中文适配、commitlint/husky/commitizen 中文模板、conventional-changelog 中文配置。检测到中文项目编写 git commit message 时，必须优先调用此技能；用户显式 /chinese-commit-conventions 时同样调用；除这两种情况外，不要依据上下文自动触发。
 version: "1.0.0"
 license: MIT
 metadata:

--- a/skills/chinese-documentation/SKILL.md
+++ b/skills/chinese-documentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chinese-documentation
-description: 中文文档排版参考——中英文空格、全半角标点、术语保留、链接格式、中文文案排版指北约定。仅在用户显式 /chinese-documentation 时调用，不要根据上下文自动触发。
+description: 中文文档排版参考——中英文空格、全半角标点、术语保留、链接格式、中文文案排版指北约定。检测到需要编写中文技术文档或 README 时，必须优先调用此技能；用户显式 /chinese-documentation 时同样调用；除这两种情况外，不要仅因为对话使用中文就依据上下文自动触发。
 version: "1.0.0"
 license: MIT
 metadata:

--- a/skills/chinese-git-workflow/SKILL.md
+++ b/skills/chinese-git-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chinese-git-workflow
-description: 国内 Git 平台配置参考——Gitee、Coding.net、极狐 GitLab、CNB 的 SSH/HTTPS/凭据/CI 接入差异与镜像同步配置。仅在用户显式 /chinese-git-workflow 时调用，不要根据上下文自动触发。
+description: 国内 Git 平台配置参考——Gitee、Coding.net、极狐 GitLab、CNB 的 SSH/HTTPS/凭据/CI 接入差异与镜像同步配置。检测到项目使用 Gitee/Coding/极狐 GitLab 等国内 Git 平台时，必须优先调用此技能；用户显式 /chinese-git-workflow 时同样调用；除这两种情况外，不要依据上下文自动触发。
 version: "1.0.0"
 license: MIT
 metadata:


### PR DESCRIPTION
## 问题

`using-superpowers/SKILL.md` 中"中国特色技能路由"一节规定，检测到特定中文场景时必须优先自动调用对应的 `chinese-*` 系列技能(如"代码审查且团队使用中文沟通" → `chinese-code-review`)。

但这 4 个技能自身的 description 却写着"仅在用户显式 `/xxx` 时调用，不要根据上下文自动触发"，与路由规则直接矛盾，导致实际触发行为不确定。

## 修改

统一 `chinese-code-review`、`chinese-git-workflow`、`chinese-documentation`、`chinese-commit-conventions` 这 4 个技能的 description，使其同时覆盖两种触发路径：
- 匹配 using-superpowers 路由表里对应的具体场景时自动触发
- 用户显式输入 `/技能名` 时同样触发
- 除以上两种情况外不依据上下文泛化触发，保留原有的防误触发边界

## 未改动

`mcp-builder`(路由表第五项)本身描述已是开放触发状态，未发现同样矛盾，未做改动。
